### PR TITLE
feat(chatroom): 드래프트 및 채팅방 페이지의 기능 리팩토링(#49)

### DIFF
--- a/src/pages/Chatroom.css
+++ b/src/pages/Chatroom.css
@@ -65,8 +65,12 @@ body {
 }
 
 @keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.5; }
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
 }
 
 .exit-btn {
@@ -350,7 +354,7 @@ body {
 .formation-field {
   background: linear-gradient(180deg, #4CAF50 0%, #45a049 100%);
   border-radius: 10px;
-  padding: 2rem 1rem;
+  padding: 1rem;
   height: calc(100% - 3rem);
   position: relative;
   overflow-y: auto;
@@ -363,9 +367,8 @@ body {
   left: 0;
   right: 0;
   bottom: 0;
-  background:
-      linear-gradient(0deg, rgba(255,255,255,0.3) 1px, transparent 1px),
-      linear-gradient(90deg, rgba(255,255,255,0.3) 1px, transparent 1px);
+  background: linear-gradient(0deg, rgba(255, 255, 255, 0.3) 1px, transparent 1px),
+  linear-gradient(90deg, rgba(255, 255, 255, 0.3) 1px, transparent 1px);
   background-size: 50px 50px;
 }
 
@@ -388,13 +391,29 @@ body {
 }
 
 .player-card {
+  position: relative;
   background: rgba(255, 255, 255, 0.95);
-  border-radius: 8px;
-  padding: 0.5rem;
+  border-radius: 10px;
+  padding: 0.8rem;
   text-align: center;
-  min-width: 80px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  min-width: 100px;
+  max-width: 120px;
+  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.15);
   transition: transform 0.2s ease;
+}
+
+.player-points-badge {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  padding: 2px 6px;
+  border-radius: 9999px;
+  font-size: 12px;
+  font-weight: 700;
+  background: #e8f5e9; /* 연한 초록 배경 */
+  border: 1px solid #c8e6c9; /* 경계선 */
+  color: #1b5e20;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.12);
 }
 
 .player-card:hover {
@@ -402,30 +421,46 @@ body {
 }
 
 .player-photo-small {
-  width: 40px;
-  height: 40px;
+  width: 50px;                /* 좀 더 크게 */
+  height: 50px;
   border-radius: 50%;
-  background: linear-gradient(45deg, #667eea, #764ba2);
-  margin: 0 auto 0.3rem;
+  overflow: hidden;           /* ★ 원형 크롭 */
+  background: linear-gradient(45deg, #37474f, #546e7a); /* 자연스러운 회색 그라데이션 */
+  margin: 0 auto 0.5rem;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid rgba(255, 255, 255, 0.8);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.player-photo-small img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
 }
 
 .player-name-small {
-  font-size: 0.7rem;
+  font-size: 0.8rem;
   font-weight: bold;
   color: #333;
   line-height: 1.2;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin-bottom: 0.3rem;
 }
 
 .player-position-badge {
   background: linear-gradient(45deg, #ff6b6b, #ff8e8e);
   color: white;
-  font-size: 0.6rem;
-  padding: 0.1rem 0.3rem;
+  font-size: 0.7rem;
+  padding: 0.2rem 0.4rem;
   border-radius: 8px;
   margin-top: 0.2rem;
+  font-weight: 600;
 }
 
 /* ========== 오른쪽 섹션 (채팅) ========== */
@@ -731,8 +766,12 @@ body {
 }
 
 @keyframes fadeInOut {
-  0%, 100% { opacity: 0.5; }
-  50% { opacity: 1; }
+  0%, 100% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 1;
+  }
 }
 
 .chat-end-message {
@@ -806,9 +845,13 @@ body {
     padding: 0.3rem;
   }
 
-  .player-photo-small {
-    width: 30px;
-    height: 30px;
+
+  .player-photo-small img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;          /* ★ 원형에 꽉 차게 */
+    object-position: center top;
+    display: block;
   }
 
   .player-name-small {

--- a/src/pages/Draft.css
+++ b/src/pages/Draft.css
@@ -170,11 +170,11 @@ body {
 }
 
 @keyframes scaleIn {
-    from { 
+    from {
         transform: scale(0.5);
         opacity: 0;
     }
-    to { 
+    to {
         transform: scale(1);
         opacity: 1;
     }
@@ -493,11 +493,11 @@ body {
 }
 
 @keyframes selectingPulse {
-    0%, 100% { 
+    0%, 100% {
         background: linear-gradient(45deg, #ff9800, #f57c00);
         transform: scale(1);
     }
-    50% { 
+    50% {
         background: linear-gradient(45deg, #ffa726, #fb8c00);
         transform: scale(1.02);
     }
@@ -579,10 +579,10 @@ body {
 }
 
 @keyframes selectedPulse {
-    0%, 100% { 
+    0%, 100% {
         box-shadow: 0 4px 15px rgba(76, 175, 80, 0.3);
     }
-    50% { 
+    50% {
         box-shadow: 0 6px 20px rgba(76, 175, 80, 0.5);
         transform: scale(1.02);
     }
@@ -618,11 +618,11 @@ body {
 }
 
 @keyframes botActivePulse {
-    0%, 100% { 
+    0%, 100% {
         transform: scale(1);
         box-shadow: 0 4px 15px rgba(255, 152, 0, 0.4);
     }
-    50% { 
+    50% {
         transform: scale(1.03);
         box-shadow: 0 8px 25px rgba(255, 152, 0, 0.6);
     }
@@ -635,11 +635,11 @@ body {
 }
 
 @keyframes activePulse {
-    0%, 100% { 
+    0%, 100% {
         transform: scale(1);
         box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4);
     }
-    50% { 
+    50% {
         transform: scale(1.03);
         box-shadow: 0 8px 25px rgba(102, 126, 234, 0.6);
     }
@@ -771,24 +771,24 @@ body {
     .section {
         min-height: 300px;
     }
-    
+
     .countdown-content h2 {
         font-size: 2rem;
     }
-    
+
     .countdown-content {
         padding: 2rem 3rem;
     }
-    
+
     .users-grid {
         grid-template-columns: 1fr;
     }
-    
+
     .draft-info {
         gap: 1rem;
         font-size: 0.9rem;
     }
-    
+
     .my-players {
         max-height: 300px;
     }
@@ -800,34 +800,34 @@ body {
         flex-wrap: wrap;
         gap: 0.5rem;
     }
-    
+
     .draft-info {
         order: 3;
         width: 100%;
         justify-content: center;
     }
-    
+
     .countdown-content {
         padding: 1.5rem 2rem;
     }
-    
+
     .countdown-content h2 {
         font-size: 1.5rem;
     }
-    
+
     .warning-content {
         padding: 1.5rem 2rem;
     }
-    
+
     .warning-content p {
         font-size: 1.2rem;
     }
-    
+
     .my-players {
         max-height: 250px;
     }
 }333;
-    font-size: 0.9rem;
+font-size: 0.9rem;
 }
 
 /* 드래프트 완료 상태에서의 특별한 스타일 */
@@ -851,19 +851,19 @@ body {
     .section {
         min-height: 300px;
     }
-    
+
     .countdown-content h2 {
         font-size: 2rem;
     }
-    
+
     .countdown-content {
         padding: 2rem 3rem;
     }
-    
+
     .users-grid {
         grid-template-columns: 1fr;
     }
-    
+
     .draft-info {
         gap: 1rem;
         font-size: 0.9rem;
@@ -876,25 +876,25 @@ body {
         flex-wrap: wrap;
         gap: 0.5rem;
     }
-    
+
     .draft-info {
         order: 3;
         width: 100%;
         justify-content: center;
     }
-    
+
     .countdown-content {
         padding: 1.5rem 2rem;
     }
-    
+
     .countdown-content h2 {
         font-size: 1.5rem;
     }
-    
+
     .warning-content {
         padding: 1.5rem 2rem;
     }
-    
+
     .warning-content p {
         font-size: 1.2rem;
     }

--- a/src/pages/Draft.css
+++ b/src/pages/Draft.css
@@ -62,10 +62,10 @@ body {
 }
 
 @keyframes timerPulse {
-    0%, 100% { 
+    0%, 100% {
         box-shadow: 0 2px 10px rgba(255, 107, 107, 0.3);
     }
-    50% { 
+    50% {
         box-shadow: 0 4px 20px rgba(255, 107, 107, 0.6);
         transform: scale(1.02);
     }
@@ -158,6 +158,34 @@ body {
     animation: shake 0.5s ease-in-out;
 }
 
+/* 선수 선택 알림 메시지 오버레이 */
+.player-select-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    animation: fadeIn 0.3s ease-in-out;
+}
+
+.player-select-content {
+    background-color: #28a745;
+    color: white;
+    padding: 20px 40px;
+    border-radius: 10px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    text-align: center;
+    font-size: 18px;
+    font-weight: bold;
+    max-width: 400px;
+    animation: slideInUp 0.3s ease-in-out;
+}
+
 @keyframes shake {
     0%, 100% { transform: translateX(0); }
     25% { transform: translateX(-5px); }
@@ -176,6 +204,17 @@ body {
     }
     to {
         transform: scale(1);
+        opacity: 1;
+    }
+}
+
+@keyframes slideInUp {
+    from {
+        transform: translateY(50px);
+        opacity: 0;
+    }
+    to {
+        transform: translateY(0);
         opacity: 1;
     }
 }
@@ -823,79 +862,13 @@ body {
         font-size: 1.2rem;
     }
 
+    .player-select-content {
+        padding: 15px 30px;
+        font-size: 16px;
+        max-width: 350px;
+    }
+
     .my-players {
         max-height: 250px;
-    }
-}333;
-font-size: 0.9rem;
-}
-
-/* 드래프트 완료 상태에서의 특별한 스타일 */
-.draft-completed .timer {
-    background: linear-gradient(45deg, #4CAF50, #45a049);
-    animation: none;
-}
-
-.draft-completed .user-card.active {
-    animation: none;
-    background: linear-gradient(45deg, #4CAF50, #45a049);
-}
-
-/* 반응형 디자인 */
-@media (max-width: 1200px) {
-    .main-container {
-        flex-direction: column;
-        height: auto;
-    }
-
-    .section {
-        min-height: 300px;
-    }
-
-    .countdown-content h2 {
-        font-size: 2rem;
-    }
-
-    .countdown-content {
-        padding: 2rem 3rem;
-    }
-
-    .users-grid {
-        grid-template-columns: 1fr;
-    }
-
-    .draft-info {
-        gap: 1rem;
-        font-size: 0.9rem;
-    }
-}
-
-@media (max-width: 768px) {
-    .header {
-        padding: 0.5rem 1rem;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-    }
-
-    .draft-info {
-        order: 3;
-        width: 100%;
-        justify-content: center;
-    }
-
-    .countdown-content {
-        padding: 1.5rem 2rem;
-    }
-
-    .countdown-content h2 {
-        font-size: 1.5rem;
-    }
-
-    .warning-content {
-        padding: 1.5rem 2rem;
-    }
-
-    .warning-content p {
-        font-size: 1.2rem;
     }
 }

--- a/src/pages/Draft.jsx
+++ b/src/pages/Draft.jsx
@@ -1,30 +1,87 @@
 // src/pages/Draft.jsx
 window.global = window;
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 import './Draft.css';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
+import { useInView } from 'react-intersection-observer';
+import debounce from 'lodash.debounce';
+import axios from 'axios';
+
+// axiosInstance 직접 생성 (동적 토큰 처리)
+const axiosInstance = axios.create({
+    baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
+});
+
+// WebSocket URL 처리 (Chatroom.jsx와 동일한 로직)
+const RAW_WS_BASE =
+    (typeof import.meta !== 'undefined' &&
+        import.meta.env &&
+        import.meta.env.VITE_API_WS_URL) ||
+    (typeof window !== 'undefined' && window.REACT_APP_WS_BASE_URL) ||
+    'ws://localhost:8080';
+
+// 끝 슬래시 제거 + ws/wss → http/https 변환
+const SOCKJS_ORIGIN = RAW_WS_BASE
+    .replace(/\/$/, '')
+    .replace(/^wss:\/\//, 'https://')
+    .replace(/^ws:\/\//, 'http://');
+
+// 요청 인터셉터 추가
+axiosInstance.interceptors.request.use(
+    (config) => {
+        const token = localStorage.getItem('accessToken');
+        if (token) {
+            config.headers['Authorization'] = `Bearer ${token}`;
+        }
+        return config;
+    },
+    (error) => {
+        return Promise.reject(error);
+    }
+);
 
 export default function Draft() {
     const [draftTime, setDraftTime] = useState(45);
     const [myPlayerCount, setMyPlayerCount] = useState(2);
-    const [chatList, setChatList] = useState([
-        { user: 'test1234@gmail.com', message: '좋은 선수들이 많네요!' },
-        { user: 'soccer_king@gmail.com', message: '손흥민 누가 뽑을까요? ㅎㅎ' },
-        { user: 'fantasy_master@gmail.com', message: '홀란드 먼저 가야죠' },
-        { user: 'epl_lover@gmail.com', message: '전술 짜는 재미가 있네요' }
-    ]);
+    const [chatList, setChatList] = useState([]);
     const [message, setMessage] = useState('');
+    const [isComposing, setIsComposing] = useState(false);
+
+    // 무한스크롤 관련 상태
+    const [hasMore, setHasMore] = useState(true);
+    const [loading, setLoading] = useState(false);
+    const [nextCursor, setNextCursor] = useState(null);
+    const [isInitialLoad, setIsInitialLoad] = useState(true);
+
+    // 채팅 검색 관련 상태
+    const [searchQuery, setSearchQuery] = useState('');
+    const [searchResults, setSearchResults] = useState([]);
+    const [isSearching, setIsSearching] = useState(false);
+    const [showSearchResults, setShowSearchResults] = useState(false);
+
+    // 사용자 정보
+    const [currentUser, setCurrentUser] = useState(null);
+
+    // 채팅방 ID (draft ID와 다름)
+    const [chatRoomId, setChatRoomId] = useState(null);
+
+    // 읽음 표시 관련 상태
+    const [lastReadMessageId, setLastReadMessageId] = useState(null);
+    const [unreadCount, setUnreadCount] = useState(0);
+
+    // WebSocket 연결 상태
+    const [isConnected, setIsConnected] = useState(false);
     const [players, setPlayers] = useState([]); // 백엔드에서 받아온 선수 데이터
-    const [loading, setLoading] = useState(true); // 로딩 상태
+    const [playersLoading, setPlayersLoading] = useState(true); // 선수 로딩 상태
     const [error, setError] = useState(null); // 에러 상태
     const [elementTypes, setElementTypes] = useState([]); // 포지션 타입 데이터
     const [searchParams, setSearchParams] = useState({
         keyword: '',
         elementTypeId: ''
     }); // 검색 파라미터
-    
+
     // 새로 추가된 상태들
     const [participants, setParticipants] = useState([]); // 드래프트 참가자 목록
     const [participantLoading, setParticipantLoading] = useState(true);
@@ -34,7 +91,7 @@ export default function Draft() {
     const [draftStarted, setDraftStarted] = useState(false); // 드래프트 시작 여부
     const [currentTurnIndex, setCurrentTurnIndex] = useState(0); // 현재 턴 인덱스
     const [turnTimer, setTurnTimer] = useState(null); // 턴 타이머
-    
+
     // 드래프트 관련 새로운 상태들
     const [participantPickCounts, setParticipantPickCounts] = useState({}); // 각 참가자별 선택한 선수 수
     const [draftCompleted, setDraftCompleted] = useState(false); // 드래프트 완료 여부
@@ -43,27 +100,486 @@ export default function Draft() {
     const [botAutoSelectTimer, setBotAutoSelectTimer] = useState(null); // Bot 자동 선택 타이머
     const [selectedPlayerIds, setSelectedPlayerIds] = useState([]); // 이미 선택된 선수 ID 목록
     const [isTimerPaused, setIsTimerPaused] = useState(false); // 타이머 일시정지 상태
-    
+
     // 드래프트된 선수 관련 상태들
     const [draftedPlayers, setDraftedPlayers] = useState([]); // 드래프트된 선수 전체 리스트
     const [selectedParticipantId, setSelectedParticipantId] = useState(null); // 선택된 참가자 ID
     const [draftedPlayersLoading, setDraftedPlayersLoading] = useState(false); // 드래프트된 선수 로딩 상태
     const [draftedPlayersError, setDraftedPlayersError] = useState(null); // 드래프트된 선수 에러 상태
-    
+
     const chatBoxRef = useRef(null);
+    const chatRef = useRef(null);
+
+    // 무한스크롤 감지를 위한 IntersectionObserver
+    const { ref: loadMoreRef, inView } = useInView({
+        threshold: 0,
+        rootMargin: '100px 0px',
+    });
     const navigate = useNavigate();
     const { draftId } = useParams(); // URL에서 draftId 파라미터 가져오기
-    const stompClientRef = useRef(null);
+    const stompClientRef = useRef(null); // 드래프트용 WebSocket
+    const chatStompClientRef = useRef(null); // 채팅용 WebSocket
     const autoSelectTimeoutRef = useRef(null);
     const retryTimeoutRef = useRef(null);
-    
+
+    // JWT 토큰 가져오기
+    const getAuthToken = () => {
+        return localStorage.getItem('accessToken') || sessionStorage.getItem('accessToken');
+    };
+
+    // 현재 사용자 정보 가져오기
+    const fetchCurrentUser = async () => {
+        try {
+            const response = await axiosInstance.get('/api/user/me');
+            setCurrentUser(response.data);
+        } catch (error) {
+            console.error('사용자 정보 로드 실패:', error);
+            // 임시 사용자 정보 설정
+            setCurrentUser({
+                id: localStorage.getItem('userId') || 'test-user',
+                email: localStorage.getItem('userEmail') || 'test@gmail.com'
+            });
+        }
+    };
+
+    // Draft.jsx
+    const fetchChatRoomId = async () => {
+        try {
+            // 1) 드래프트로 채팅방 조회
+            const { data } = await axiosInstance.get(`/api/chat-rooms/by-draft/${draftId}`);
+            setChatRoomId(data.id);
+            return data.id;
+        } catch (error) {
+            console.error('❌ Chat Room ID 조회 실패:', error?.response?.status, error?.message);
+
+            // 2) 404면 채팅방을 생성(백엔드 스펙에 맞게 URL/바디 조정)
+            if (error?.response?.status === 404) {
+                try {
+                    // (A안) POST /api/chat-rooms  { draftId }
+                    const { data: created } = await axiosInstance.post('/api/chat-rooms', { draftId });
+                    setChatRoomId(created.id);
+                    console.log('✅ 채팅방 생성 성공:', created.id);
+                    return created.id;
+                } catch (e2) {
+                    console.error('❌ 채팅방 생성 실패:', e2?.response?.status, e2?.message);
+
+                    // (B안) 만약 생성 엔드포인트가 /api/chat-rooms/by-draft/{draftId} POST 라면:
+                    // const { data: created } = await axiosInstance.post(`/api/chat-rooms/by-draft/${draftId}`);
+
+                    // 3) 최후 수단 Fallback: 기존처럼 draftId를 그대로 사용 (백엔드가 draftId 기준으로도 동작하던 환경용)
+                    // 👉 백엔드가 반드시 chat_room.id를 요구한다면 이 fallback은 주석 처리하고 BE 먼저 수정하세요.
+                    setChatRoomId(draftId);
+                    console.warn('⚠️ 서버에 채팅방이 없어 draftId를 임시 roomId로 사용합니다. (BE 정비 전 임시)');
+                    return draftId;
+                }
+            }
+
+            return null;
+        }
+    };
+
+
+    // 시간 포맷
+    const formatTime = (timestamp) => {
+        const date = new Date(timestamp);
+        return date.toLocaleTimeString('ko-KR', {
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true
+        });
+    };
+
+    // 메시지 포맷 변환
+    const formatMessage = useCallback((item) => {
+        let userName = '시스템';
+        if (item.type === 'ALERT' || item.type === 'SYSTEM') {
+            userName = '⚽ 알림';
+        } else if (item.userId) {
+            if (currentUser && item.userId === currentUser.id) {
+                userName = currentUser.email;
+            } else {
+                userName = 'Unknown';
+            }
+        }
+
+        return {
+            id: item.id,
+            user: userName,
+            text: item.content,
+            time: formatTime(item.createdAt),
+            type: item.type,
+            userId: item.userId
+        };
+    }, [currentUser]);
+
+    // 채팅 히스토리 초기 로드 (최신 메시지부터)
+    const loadInitialHistory = async () => {
+        if (loading) return;
+        setLoading(true);
+
+        try {
+            const response = await axiosInstance.get(`/api/chat-rooms/${chatRoomId}/messages`, {
+                params: { limit: 20 }
+            });
+
+            const { items, nextCursor: cursor, hasMore: more } = response.data;
+
+            setChatList(items.map(formatMessage));
+            setNextCursor(cursor);
+            setHasMore(more);
+            setIsInitialLoad(false);
+
+            // 초기 로드 완료 후 즉시 맨 아래로 스크롤
+            requestAnimationFrame(() => {
+                if (chatRef.current) {
+                    chatRef.current.scrollTop = chatRef.current.scrollHeight;
+                }
+            });
+
+        } catch (error) {
+            console.error('채팅 히스토리 초기 로드 실패:', error);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    // 이전 메시지 로드 (무한스크롤)
+    const loadMoreMessages = async () => {
+        if (loading || !nextCursor || !hasMore) return;
+        setLoading(true);
+
+        try {
+            const response = await axiosInstance.get(`/api/chat-rooms/${chatRoomId}/messages/before`, {
+                params: {
+                    cursor: nextCursor,
+                    limit: 20
+                }
+            });
+
+            const { items, nextCursor: cursor, hasMore: more } = response.data;
+
+            const currentScrollHeight = chatRef.current?.scrollHeight || 0;
+
+            setChatList(prev => [...items.map(formatMessage), ...prev]);
+            setNextCursor(cursor);
+            setHasMore(more);
+
+            setTimeout(() => {
+                if (chatRef.current) {
+                    const newScrollHeight = chatRef.current.scrollHeight;
+                    const heightDiff = newScrollHeight - currentScrollHeight;
+                    chatRef.current.scrollTop = chatRef.current.scrollTop + heightDiff;
+                }
+            }, 50);
+
+        } catch (error) {
+            console.error('이전 메시지 로드 실패:', error);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    // 채팅 검색 함수
+    const searchChatMessages = async (query) => {
+        if (!query.trim()) {
+            setSearchResults([]);
+            setShowSearchResults(false);
+            return;
+        }
+
+        setIsSearching(true);
+        try {
+            const response = await axiosInstance.get(`/api/chat-rooms/${chatRoomId}/search`, {
+                params: {
+                    q: query.trim(),
+                    limit: 20
+                }
+            });
+
+            const { items } = response.data;
+            setSearchResults(items.map(formatMessage));
+            setShowSearchResults(true);
+        } catch (error) {
+            console.error('채팅 검색 실패:', error);
+            setSearchResults([]);
+            setShowSearchResults(false);
+        } finally {
+            setIsSearching(false);
+        }
+    };
+
+    // 채팅 검색 실행
+    const handleChatSearch = () => {
+        searchChatMessages(searchQuery);
+    };
+
+    // 검색 초기화
+    const clearSearch = () => {
+        setSearchQuery('');
+        setSearchResults([]);
+        setShowSearchResults(false);
+    };
+
+    // 읽음 상태 조회
+    const fetchReadState = async () => {
+        try {
+            const response = await axiosInstance.get(`/api/chat-rooms/${chatRoomId}/read-state`);
+            setLastReadMessageId(response.data.lastReadMessageId);
+            setUnreadCount(response.data.unreadCount);
+        } catch (error) {
+            console.error('읽음 상태 조회 실패:', error);
+        }
+    };
+
+    // 읽음 표시 업데이트
+    const markReadUpTo = async (messageId) => {
+        try {
+            const response = await axiosInstance.post(`/api/chat-rooms/${chatRoomId}/read-state`, {
+                messageId: messageId
+            });
+            setUnreadCount(response.data.unreadCount);
+            setLastReadMessageId(messageId);
+        } catch (error) {
+            console.error('읽음 표시 업데이트 실패:', error);
+        }
+    };
+
+    // 읽음 표시 업데이트 디바운스
+    const debouncedMarkRead = useCallback(
+        debounce((messageId) => {
+            markReadUpTo(messageId);
+        }, 1000),
+        [chatRoomId]);
+
     // draftId 확인을 위한 로그
+    // 무한스크롤 로드 디바운스
+    const debouncedLoadMore = useCallback(
+        debounce(() => {
+            if (hasMore && !loading && !isInitialLoad) {
+                loadMoreMessages();
+            }
+        }, 300),
+        [hasMore, loading, nextCursor, isInitialLoad]
+    );
+
+    // 무한스크롤 트리거
     useEffect(() => {
-        console.log('Current draftId from URL:', draftId);
+        if (inView && hasMore && !loading && !isInitialLoad) {
+            debouncedLoadMore();
+        }
+    }, [inView, hasMore, loading, isInitialLoad, debouncedLoadMore]);
+
+    // 채팅 WebSocket 연결
+    const connectChatWebSocket = useCallback(() => {
+        if (chatStompClientRef.current?.connected || !chatRoomId) return;
+
+        const token = getAuthToken();
+        if (!token) {
+            console.error('채팅 인증 토큰이 없습니다.');
+            setIsConnected(false);
+            return;
+        }
+
+        console.log('=== 채팅 WebSocket 연결 시도 ===');
+        console.log('draftId:', draftId);
+        console.log('chatRoomId:', chatRoomId);
+        console.log('token 존재:', !!token);
+        console.log('wsUrl:', import.meta.env.VITE_API_WS_URL || 'ws://localhost:8080');
+
+        try {
+            const socket = new SockJS(`${SOCKJS_ORIGIN}/ws`);
+            const chatStompClient = new Client({
+                webSocketFactory: () => socket,
+                connectHeaders: {
+                    'Authorization': `Bearer ${token}`
+                },
+                debug: (str) => {
+                    console.log('Chat STOMP Debug:', str);
+                },
+                onConnect: (frame) => {
+                    console.log('✅ 채팅 WebSocket 연결 성공:', frame);
+                    console.log('채팅방 구독 시도:', `/topic/chat/${chatRoomId}`);
+                    setIsConnected(true);
+
+                    // 채팅방 구독 (실제 chatRoomId 사용)
+                    const subscription = chatStompClient.subscribe(`/topic/chat/${chatRoomId}`, (message) => {
+                        console.log('✅ 채팅 메시지 수신:', message.body);
+                        const newMessage = JSON.parse(message.body);
+
+                        let userName = '시스템';
+                        if (newMessage.type === 'ALERT' || newMessage.type === 'SYSTEM') {
+                            userName = '⚽ 알림';
+                        } else if (newMessage.userId) {
+                            if (currentUser && newMessage.userId === currentUser.id) {
+                                userName = currentUser.email;
+                            } else {
+                                userName = 'Unknown';
+                            }
+                        }
+
+                        const formattedMessage = {
+                            id: newMessage.id || Date.now().toString(),
+                            user: userName,
+                            text: newMessage.content,
+                            time: formatTime(newMessage.createdAt || new Date()),
+                            type: newMessage.type,
+                            userId: newMessage.userId
+                        };
+
+                        setChatList(prev => {
+                            const newList = [...prev, formattedMessage];
+
+                            setTimeout(() => {
+                                if (chatRef.current) {
+                                    chatRef.current.scrollTop = chatRef.current.scrollHeight;
+                                }
+                            }, 100);
+
+                            return newList;
+                        });
+                    },{ Authorization: `Bearer ${token}` });
+
+                    console.log('채팅 구독 완료:', subscription);
+                },
+                onDisconnect: (frame) => {
+                    console.log('채팅 WebSocket 연결 해제:', frame);
+                    setIsConnected(false);
+                },
+                onStompError: (frame) => {
+                    console.error('채팅 STOMP 오류:', frame);
+                    setIsConnected(false);
+
+                    setTimeout(() => {
+                        if (!chatStompClientRef.current?.connected) {
+                            console.log('채팅 재연결 시도...');
+                            connectChatWebSocket();
+                        }
+                    }, 3000);
+                },
+                onWebSocketError: (error) => {
+                    console.error('채팅 WebSocket 오류:', error);
+                },
+                reconnectDelay: 5000,
+                heartbeatIncoming: 4000,
+                heartbeatOutgoing: 4000
+            });
+
+            chatStompClient.activate();
+            chatStompClientRef.current = chatStompClient;
+            console.log('채팅 STOMP 클라이언트 활성화됨');
+        } catch (error) {
+            console.error('채팅 WebSocket 연결 실패:', error);
+            setIsConnected(false);
+        }
+    }, [draftId, chatRoomId, currentUser]);
+
+    useEffect(() => {
         if (!draftId) {
             console.error('draftId is missing from URL parameters');
+            return;
         }
+        (async () => {
+            await fetchCurrentUser();
+            await fetchChatRoomId();  // chatRoomId 세팅
+        })();
     }, [draftId]);
+
+    useEffect(() => {
+        if (!chatRoomId) return;
+        // 순서 중요: 히스토리/읽음 먼저, 그다음 WS
+        (async () => {
+            await loadInitialHistory();
+            await fetchReadState();
+            if (currentUser && !isConnected) {
+                connectChatWebSocket();
+            }
+        })();
+    }, [chatRoomId, currentUser]);
+
+    // 사용자 정보 로드 후 WebSocket 연결
+    useEffect(() => {
+        if (currentUser && !isConnected) {
+            connectChatWebSocket();
+        }
+    }, [currentUser, connectChatWebSocket]);
+
+    // 사용자 정보 업데이트 시 기존 메시지 다시 포맷팅
+    useEffect(() => {
+        if (currentUser && chatList.length > 0) {
+            setChatList(prevList =>
+                prevList.map(msg => ({
+                    ...msg,
+                    user: (() => {
+                        if (!msg.userId || msg.user === '⚽ 알림' || msg.user === '시스템') {
+                            return msg.user;
+                        }
+
+                        if (currentUser && msg.userId === currentUser.id) {
+                            return currentUser.email;
+                        } else {
+                            return msg.user;
+                        }
+                    })()
+                }))
+            );
+        }
+    }, [currentUser]);
+
+    // 새 메시지 추가 시 스크롤 및 읽음 표시 업데이트
+    useEffect(() => {
+        if (chatRef.current && chatList.length > 0) {
+            const { scrollTop, scrollHeight, clientHeight } = chatRef.current;
+            const isNearBottom = scrollHeight - scrollTop - clientHeight < 100;
+
+            if (isNearBottom) {
+                setTimeout(() => {
+                    if (chatRef.current) {
+                        chatRef.current.scrollTop = chatRef.current.scrollHeight;
+                    }
+                }, 100);
+
+                const lastMessage = chatList[chatList.length - 1];
+                if (lastMessage && lastMessage.id !== lastReadMessageId) {
+                    debouncedMarkRead(lastMessage.id);
+                }
+            }
+        }
+    }, [chatList, lastReadMessageId, debouncedMarkRead]);
+
+    // 스크롤 이벤트로 읽음 표시 업데이트
+    useEffect(() => {
+        const handleScroll = () => {
+            if (!chatRef.current || chatList.length === 0) return;
+
+            const { scrollTop, scrollHeight, clientHeight } = chatRef.current;
+            const isNearBottom = scrollHeight - scrollTop - clientHeight < 100;
+
+            if (isNearBottom) {
+                const lastMessage = chatList[chatList.length - 1];
+                if (lastMessage && lastMessage.id !== lastReadMessageId) {
+                    debouncedMarkRead(lastMessage.id);
+                }
+            }
+        };
+
+        const chatElement = chatRef.current;
+        if (chatElement) {
+            chatElement.addEventListener('scroll', handleScroll);
+            return () => chatElement.removeEventListener('scroll', handleScroll);
+        }
+    }, [chatList, lastReadMessageId, debouncedMarkRead]);
+
+    // 드래프트 완료 시 자동으로 채팅방으로 리다이렉트
+    useEffect(() => {
+        if (draftCompleted) {
+            const redirectTimer = setTimeout(() => {
+                console.log('Draft completed, redirecting to chatroom...');
+                navigate(`/chatroom/${chatRoomId}`);
+            }, 3000); // 3초 후 자동 리다이렉트
+
+            return () => clearTimeout(redirectTimer);
+        }
+    }, [draftCompleted, navigate, chatRoomId]);
 
     // 새로고침 방지 및 창 닫기 확인 기능
     useEffect(() => {
@@ -75,7 +591,7 @@ export default function Draft() {
                 alert('드래프트 중 새로고침은 불가합니다.');
                 return false;
             }
-            
+
             // Ctrl+R (새로고침) 방지
             if ((e.ctrlKey || e.metaKey) && e.key === 'r') {
                 e.preventDefault();
@@ -105,17 +621,17 @@ export default function Draft() {
 
     // Bot 판별 함수
     const isBot = (participant) => {
-        return participant.userFlag === false && 
+        return participant.userFlag === false &&
                (participant.userName === null || participant.userName.trim() === "");
     };
 
     // 현재 사용자의 차례인지 확인하는 함수
     const isMyTurn = () => {
         if (!draftStarted || draftCompleted || participants.length === 0) return false;
-        
+
         const currentParticipant = participants[currentTurnIndex];
         if (!currentParticipant) return false;
-        
+
         // Bot이 아니고 userFlag가 true인 경우 사용자의 차례
         return !isBot(currentParticipant) && currentParticipant.userFlag === true;
     };
@@ -140,43 +656,43 @@ export default function Draft() {
     const checkPositionLimit = (selectedPlayer) => {
         const currentParticipant = participants[currentTurnIndex];
         if (!currentParticipant) return { isValid: false, message: '참가자 정보를 찾을 수 없습니다.' };
-        
+
         // 현재 참가자가 선택한 선수들 필터링
         const currentParticipantDraftedPlayers = draftedPlayers.filter(
             player => player.participantId === currentParticipant.participantId
         );
-        
+
         // 현재 선택하려는 포지션과 같은 포지션의 선수들 필터링
         const samePositionPlayers = currentParticipantDraftedPlayers.filter(
             player => player.elementTypeId === selectedPlayer.elementTypeId
         );
-        
+
         // 해당 포지션의 최대 선택 가능 수 찾기
         const elementType = elementTypes.find(
             type => type.id === selectedPlayer.elementTypeId
         );
-        
+
         if (!elementType) {
             return { isValid: false, message: '포지션 정보를 찾을 수 없습니다.' };
         }
-        
+
         const maxPlayCount = elementType.squadMaxPlay;
         const currentCount = samePositionPlayers.length;
-        
+
         console.log(`Position check for ${selectedPlayer.elementTypePluralName}:`, {
             currentCount,
             maxPlayCount,
             elementTypeId: selectedPlayer.elementTypeId,
             participantId: currentParticipant.participantId
         });
-        
+
         if (currentCount >= maxPlayCount) {
             return {
                 isValid: false,
                 message: `${selectedPlayer.elementTypePluralName} 포지션은 최대 ${maxPlayCount}명까지 선택할 수 있습니다.`
             };
         }
-        
+
         return { isValid: true, message: '' };
     };
 
@@ -202,11 +718,11 @@ export default function Draft() {
 
                 const draftedPlayersData = await response.json();
                 setDraftedPlayers(draftedPlayersData);
-                
+
                 // 드래프트된 선수 ID들을 selectedPlayerIds에 추가
                 const playerIds = draftedPlayersData.map(player => player.playerId);
                 setSelectedPlayerIds(playerIds);
-                
+
                 setDraftedPlayersError(null);
 
                 console.log('Drafted players loaded:', draftedPlayersData.length, 'players');
@@ -231,7 +747,7 @@ export default function Draft() {
     // 선택된 참가자의 드래프트된 선수들 가져오기
     const getSelectedParticipantDraftedPlayers = () => {
         if (!selectedParticipantId) return [];
-        
+
         return draftedPlayers.filter(player => player.participantId === selectedParticipantId);
     };
 
@@ -263,14 +779,14 @@ export default function Draft() {
                 );
 
                 setParticipants(sortedParticipants);
-                
+
                 // 각 참가자별 선택 카운트 초기화
                 const initialCounts = {};
                 sortedParticipants.forEach(participant => {
                     initialCounts[participant.participantId] = 0;
                 });
                 setParticipantPickCounts(initialCounts);
-                
+
                 setParticipantError(null);
 
                 // 참가자 데이터를 성공적으로 가져오면 카운트다운 시작
@@ -319,24 +835,24 @@ export default function Draft() {
     const checkDraftCompletion = (updatedPickCounts) => {
         console.log('Checking draft completion with counts:', updatedPickCounts);
         console.log('Participants:', participants);
-        
+
         if (participants.length === 0) return false;
-        
+
         // 모든 참가자가 11명씩 선택했는지 확인
         const allCompleted = participants.every(participant => {
             const pickCount = updatedPickCounts[participant.participantId] || 0;
             console.log(`Participant ${participant.participantId} (${participant.userName}): ${pickCount}/11`);
             return pickCount >= 11;
         });
-        
+
         console.log('All participants completed:', allCompleted);
         return allCompleted;
     };
 
     // 선택 가능한 선수 목록 가져오기
     const getSelectablePlayers = () => {
-        return players.filter(player => 
-            isPlayerSelectable(player.status) && 
+        return players.filter(player =>
+            isPlayerSelectable(player.status) &&
             !selectedPlayerIds.includes(player.id)
         );
     };
@@ -345,16 +861,16 @@ export default function Draft() {
     const performBotAutoSelect = () => {
         const currentParticipant = participants[currentTurnIndex];
         if (!currentParticipant || !isBot(currentParticipant)) return;
-        
+
         console.log(`Bot ${currentParticipant.participantId} is auto-selecting...`);
-        
+
         const selectablePlayers = getSelectablePlayers();
         if (selectablePlayers.length === 0) {
             console.log('No selectable players available for bot');
             moveToNextTurn();
             return;
         }
-        
+
         // Bot은 포지션 제한을 고려하여 선택
         let availablePlayer = null;
         for (const player of selectablePlayers) {
@@ -364,13 +880,13 @@ export default function Draft() {
                 break;
             }
         }
-        
+
         if (!availablePlayer) {
             console.log('No available players within position limits for bot');
             moveToNextTurn();
             return;
         }
-        
+
         console.log(`Bot selecting player: ${availablePlayer.name}`);
         handlePlayerSelect(availablePlayer, true, true); // isAutoSelect, isBot
     };
@@ -379,15 +895,15 @@ export default function Draft() {
     const performUserAutoSelect = () => {
         const currentParticipant = participants[currentTurnIndex];
         if (!currentParticipant || isBot(currentParticipant)) return;
-        
+
         // 현재 참가자가 실제 사용자(data-is-user가 true)가 아닌 경우 아무것도 하지 않음
         if (currentParticipant.userFlag !== true) {
             console.log(`Not a real user (userFlag: ${currentParticipant.userFlag}), waiting for WebSocket response...`);
             return; // 대기 상태 유지, 다음 턴으로 이동하지 않음, 자동 선택하지 않음
         }
-        
+
         console.log(`User ${currentParticipant.participantId} time expired, sending random select request...`);
-        
+
         // 실제 사용자인 경우 랜덤 선택 WebSocket 통신 전송
         if (!stompClientRef.current || !stompClientRef.current.connected) {
             console.error('WebSocket not connected for random select');
@@ -411,13 +927,13 @@ export default function Draft() {
     // 시간 만료 시 처리 함수 (수정됨)
     const handleTimeExpired = () => {
         const currentParticipant = participants[currentTurnIndex];
-        
+
         // 현재 참가자가 실제 사용자(data-is-user가 true)인 경우에만 자동 선택
         if (currentParticipant && !isBot(currentParticipant) && currentParticipant.userFlag === true && !isSelectingPlayer) {
             performUserAutoSelect();
             return;
         }
-        
+
         // 그 외의 경우 (Bot이거나 data-is-user가 false인 다른 사용자) - 타이머 일시정지
         console.log(`Time expired for participant ${currentParticipant?.participantId}, pausing timer and waiting for WebSocket response...`);
         setIsTimerPaused(true);
@@ -428,12 +944,12 @@ export default function Draft() {
     // 다음 턴으로 이동 (수정됨)
     const moveToNextTurn = () => {
         if (draftCompleted) return;
-        
+
         console.log('Moving to next turn...');
-        
+
         // 타이머 일시정지 해제
         setIsTimerPaused(false);
-        
+
         // 타이머들 정리
         if (botAutoSelectTimer) {
             clearTimeout(botAutoSelectTimer);
@@ -447,7 +963,7 @@ export default function Draft() {
             clearInterval(turnTimer);
             setTurnTimer(null);
         }
-        
+
         setCurrentTurnIndex(current => {
             const nextIndex = (current + 1) % participants.length;
             setDraftTime(45); // 새로운 턴 시작시 45초로 리셋
@@ -471,21 +987,21 @@ export default function Draft() {
                     if (isTimerPaused) {
                         return prev;
                     }
-                    
+
                     if (prev <= 1) {
                         // 시간 만료 처리
                         handleTimeExpired();
-                        
+
                         // 현재 참가자 확인
                         const currentParticipant = participants[currentTurnIndex];
-                        
+
                         // 실제 사용자(data-is-user가 true)인 경우에만 45초로 리셋
-                        if (currentParticipant && 
-                            !isBot(currentParticipant) && 
+                        if (currentParticipant &&
+                            !isBot(currentParticipant) &&
                             currentParticipant.userFlag === true) {
                             return 45;
                         }
-                        
+
                         // Bot이거나 data-is-user가 false인 경우 0으로 유지
                         return 0;
                     }
@@ -506,19 +1022,19 @@ export default function Draft() {
     // 턴 시작 시 Bot 체크 (수정됨 - Bot 자동 선택 제거)
     useEffect(() => {
         if (!draftStarted || draftCompleted || participants.length === 0) return;
-        
+
         const currentParticipant = participants[currentTurnIndex];
         if (!currentParticipant) return;
-        
+
         console.log(`Turn ${currentTurnIndex}: Participant`, {
             id: currentParticipant.participantId,
             userFlag: currentParticipant.userFlag,
             userName: currentParticipant.userName,
             isBot: isBot(currentParticipant)
         });
-        
+
         // Bot 자동 선택 로직 제거 - Bot도 WebSocket 응답만 기다림
-        
+
         return () => {
             if (botAutoSelectTimer) {
                 clearTimeout(botAutoSelectTimer);
@@ -527,50 +1043,6 @@ export default function Draft() {
         };
     }, [currentTurnIndex, draftStarted, draftCompleted, participants]);
 
-    // 턴 변경 시 타이머 리셋 (수정됨)
-    useEffect(() => {
-        if (!draftStarted || draftCompleted) return;
-
-        // 타이머 일시정지 해제
-        setIsTimerPaused(false);
-
-        if (turnTimer) {
-            clearInterval(turnTimer);
-        }
-
-        const newTimer = setInterval(() => {
-            setDraftTime(prev => {
-                // 타이머가 일시정지된 경우 카운트다운 멈춤
-                if (isTimerPaused) {
-                    return prev;
-                }
-                
-                if (prev <= 1) {
-                    handleTimeExpired();
-                    
-                    // 현재 참가자 확인
-                    const currentParticipant = participants[currentTurnIndex];
-                    
-                    // 실제 사용자(data-is-user가 true)인 경우에만 45초로 리셋
-                    if (currentParticipant && 
-                        !isBot(currentParticipant) && 
-                        currentParticipant.userFlag === true) {
-                        return 45;
-                    }
-                    
-                    // Bot이거나 data-is-user가 false인 경우 0으로 유지
-                    return 0;
-                }
-                return prev - 1;
-            });
-        }, 1000);
-
-        setTurnTimer(newTimer);
-
-        return () => {
-            if (newTimer) clearInterval(newTimer);
-        };
-    }, [currentTurnIndex, draftStarted, draftCompleted]);
 
     // WebSocket 연결 설정 (일부 수정됨)
     useEffect(() => {
@@ -580,7 +1052,7 @@ export default function Draft() {
                 console.error("WebSocket 연결 실패: 토큰이 없음");
                 return;
             }
-            
+
             const socket = new SockJS(`${import.meta.env.VITE_API_BASE_URL}/ws-draft?token=Bearer ${encodeURIComponent(token)}`);
             const stompClient = new Client({
                 webSocketFactory: () => socket,
@@ -590,20 +1062,20 @@ export default function Draft() {
                 onConnect: (frame) => {
                     console.log('Connected: ' + frame);
                     console.log(`topic/draft is  ${draftId}` );
-                    
+
                     // 드래프트 토픽 구독
                     stompClient.subscribe(`/topic/draft.${draftId}`, (message) => {
                         const draftResponse = JSON.parse(message.body);
                         console.log('Received draft message:', draftResponse);
-                        
+
                         setIsSelectingPlayer(false); // 선수 선택 완료
-                        
+
                         // alreadySelected에 따른 처리
                         if (draftResponse.alreadySelected) {
                             console.log('Player already selected, retrying...');
-                            
+
                             const currentParticipant = participants[currentTurnIndex];
-                            
+
                             // Bot인 경우 다시 시도 (Bot 자동 선택 제거)
                             if (currentParticipant && isBot(currentParticipant)) {
                                 console.log('Bot retrying selection - but auto selection removed, waiting for WebSocket...');
@@ -611,7 +1083,7 @@ export default function Draft() {
                             } else {
                                 // 실제 사용자인 경우 알림만 표시하고 타이머 재시작
                                 alert('이미 선택 된 선수입니다. 다시 선택해 주시기 바랍니다.');
-                                
+
                                 // data-is-user가 false인 다른 사용자의 경우 타이머를 45초로 재시작
                                 if (currentParticipant && !isBot(currentParticipant) && currentParticipant.userFlag !== true) {
                                     setDraftTime(45);
@@ -619,15 +1091,15 @@ export default function Draft() {
                             }
                         } else {
                             console.log('Player selection successful');
-                            
+
                             // 성공적으로 선택된 경우 선수 ID 추가
                             if (draftResponse.playerId) {
                                 setSelectedPlayerIds(prev => [...prev, draftResponse.playerId]);
-                                
+
                                 // 드래프트된 선수 리스트에도 추가
                                 setDraftedPlayers(prev => [...prev, draftResponse]);
                             }
-                            
+
                             // 현재 참가자의 선택 카운트 증가
                             const currentParticipant = participants[currentTurnIndex];
                             if (currentParticipant) {
@@ -636,9 +1108,9 @@ export default function Draft() {
                                         ...prev,
                                         [currentParticipant.participantId]: (prev[currentParticipant.participantId] || 0) + 1
                                     };
-                                    
+
                                     console.log('Updated pick counts:', updatedCounts);
-                                    
+
                                     // 드래프트 완료 체크
                                     const isCompleted = checkDraftCompletion(updatedCounts);
                                     if (isCompleted) {
@@ -652,16 +1124,16 @@ export default function Draft() {
                                         }, 1000);
                                         return updatedCounts;
                                     }
-                                    
+
                                     return updatedCounts;
                                 });
-                                
+
                                 // 사용자인 경우 myPlayerCount 증가
                                 if (!isBot(currentParticipant)) {
                                     setMyPlayerCount(prev => prev + 1);
                                 }
                             }
-                            
+
                             // 드래프트가 완료되지 않은 경우에만 다음 턴으로 이동
                             setTimeout(() => {
                                 setParticipantPickCounts(currentCounts => {
@@ -709,11 +1181,11 @@ export default function Draft() {
         const fetchElementTypes = async () => {
             try {
                 const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/api/elementType/all`);
-                
+
                 if (!response.ok) {
                     throw new Error(`HTTP error! status: ${response.status}`);
                 }
-                
+
                 const elementTypeData = await response.json();
                 setElementTypes(elementTypeData);
             } catch (err) {
@@ -728,15 +1200,15 @@ export default function Draft() {
     useEffect(() => {
         const fetchPlayers = async () => {
             try {
-                setLoading(true);
+                setPlayersLoading(true);
                 const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/api/playerCache`);
-                
+
                 if (!response.ok) {
                     throw new Error(`HTTP error! status: ${response.status}`);
                 }
-                
+
                 const playerData = await response.json();
-                
+
                 // PlayerDto 데이터를 화면에 표시할 형태로 변환
                 const transformedPlayers = playerData.map(player => ({
                     // 화면 표시용 데이터
@@ -744,7 +1216,7 @@ export default function Draft() {
                     team: player.teamKrName && player.teamKrName.trim() !== '' ? player.teamKrName : player.teamName,
                     position: getPositionCode(player.elementTypePluralName),
                     pic: player.pic,
-                    
+
                     // hidden 데이터 (화면에는 안 보이지만 저장)
                     id: player.id,
                     webName: player.webName,
@@ -756,14 +1228,14 @@ export default function Draft() {
                     elementTypePluralName: player.elementTypePluralName,
                     elementTypeKrName: player.elementTypeKrName
                 }));
-                
+
                 setPlayers(transformedPlayers);
                 setError(null);
             } catch (err) {
                 console.error('선수 데이터를 가져오는데 실패했습니다:', err);
                 setError(err.message);
             } finally {
-                setLoading(false);
+                setPlayersLoading(false);
             }
         };
 
@@ -776,10 +1248,10 @@ export default function Draft() {
         if (draftCompleted) {
             return;
         }
-        
+
         const currentParticipant = participants[currentTurnIndex];
         if (!currentParticipant) return;
-        
+
         // 자동 선택이나 Bot 선택이 아닌 경우 사용자의 차례인지 확인
         if (!isAutoSelect && !isBotSelect) {
             if (!isMyTurn()) {
@@ -790,7 +1262,7 @@ export default function Draft() {
                 return;
             }
         }
-        
+
         // 현재 참가자가 Bot이 아닌데 사용자가 선택하려 하는 경우 (기존 로직)
         if (isBot(currentParticipant) && !isAutoSelect && !isBotSelect) {
             setShowWarningMessage(true);
@@ -799,12 +1271,12 @@ export default function Draft() {
             }, 3000);
             return;
         }
-        
+
         // 이미 선수 선택 중인 경우
         if (isSelectingPlayer) {
             return;
         }
-        
+
         // 포지션 제한 체크 (Bot이 아닌 사용자나 수동 선택인 경우에만)
         if (!isBotSelect && !isAutoSelect) {
             const positionCheck = checkPositionLimit(player);
@@ -813,7 +1285,7 @@ export default function Draft() {
                 return;
             }
         }
-        
+
         if (!stompClientRef.current || !stompClientRef.current.connected) {
             if (!isBotSelect) {
                 alert('서버 연결이 끊어졌습니다. 페이지를 새로고침해 주세요.');
@@ -851,23 +1323,23 @@ export default function Draft() {
         try {
             setLoading(true);
             const params = new URLSearchParams();
-            
+
             if (searchParams.keyword.trim() !== '') {
                 params.append('keyword', searchParams.keyword.trim());
             }
-            
+
             if (searchParams.elementTypeId !== '') {
                 params.append('elementTypeId', searchParams.elementTypeId);
             }
-            
+
             const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/api/playerEs/search?${params.toString()}`);
-            
+
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status}`);
             }
-            
+
             const searchResults = await response.json();
-            
+
             // PlayerEsDocument 데이터를 화면에 표시할 형태로 변환
             const transformedPlayers = searchResults.map(player => ({
                 // 화면 표시용 데이터
@@ -875,7 +1347,7 @@ export default function Draft() {
                 team: player.teamKrName && player.teamKrName.trim() !== '' ? player.teamKrName : player.teamName,
                 position: getPositionCode(player.elementTypePluralName),
                 pic: player.pic,
-                
+
                 // hidden 데이터 (화면에는 안 보이지만 저장)
                 id: player.id,
                 webName: player.webName,
@@ -887,7 +1359,7 @@ export default function Draft() {
                 elementTypePluralName: player.elementTypePluralName,
                 elementTypeKrName: player.elementTypeKrName
             }));
-            
+
             setPlayers(transformedPlayers);
             setError(null);
         } catch (err) {
@@ -935,7 +1407,7 @@ export default function Draft() {
     const isPlayerSelectable = (status) => {
         return status === 'a';
     };
-    
+
     const getPositionCode = (elementTypePluralName) => {
         switch (elementTypePluralName) {
             case 'Forwards':
@@ -951,20 +1423,37 @@ export default function Draft() {
         }
     };
 
-    const formatTime = (seconds) =>
+    const formatDraftTime = (seconds) =>
         `${String(Math.floor(seconds / 60)).padStart(2, '0')}:${String(seconds % 60).padStart(2, '0')}`;
 
-    // 채팅 전송
-    const handleSend = () => {
-        if (message.trim() === '') return;
-        setChatList(prev => [...prev, { user: '나', message }]);
-        setMessage('');
+    // 메시지 전송
+    const handleSendMessage = () => {
+        if (isComposing) return;
+        if (!message.trim()) return;
+
+        if (!chatStompClientRef.current?.connected) {
+            alert('채팅 서버에 연결되지 않았습니다. 잠시 후 다시 시도해주세요.');
+            return;
+        }
+
+        const messageData = {
+            roomId: chatRoomId,               // ← 통일
+            content: message.trim()
+        };
+
+        const token = getAuthToken();
+        try {
+            chatStompClientRef.current.publish({
+                destination: `/app/chat/${chatRoomId}/send`,   // ← 통일
+                body: JSON.stringify(messageData)
+            });
+            setMessage('');
+        } catch (error) {
+            console.error('❌ 메시지 전송 실패:', error);
+            alert('메시지 전송에 실패했습니다.');
+        }
     };
 
-    // 채팅 엔터
-    const handleKeyPress = (e) => {
-        if (e.key === 'Enter') handleSend();
-    };
 
     // 드래프트 나가기
     const handleExit = () => {
@@ -972,6 +1461,9 @@ export default function Draft() {
             // WebSocket 연결 해제
             if (stompClientRef.current) {
                 stompClientRef.current.deactivate();
+            }
+            if (chatStompClientRef.current) {
+                chatStompClientRef.current.deactivate();
             }
             // 타이머들 정리
             if (turnTimer) {
@@ -1010,14 +1502,14 @@ export default function Draft() {
         <>
             {/* Hidden draftId value */}
             <div style={{ display: 'none' }} data-draft-id={draftId}></div>
-            
+
             {/* Hidden drafted players data */}
             <div style={{ display: 'none' }} id="drafted-players-data">
                 {draftedPlayers.map((player, idx) => (
                     <div key={idx} data-drafted-player={JSON.stringify(player)}></div>
                 ))}
             </div>
-            
+
             {/* 드래프트 시작 카운트다운 오버레이 */}
             {showCountdown && (
                 <div className="countdown-overlay">
@@ -1026,16 +1518,19 @@ export default function Draft() {
                     </div>
                 </div>
             )}
-            
+
             {/* 드래프트 완료 오버레이 */}
             {draftCompleted && (
                 <div className="countdown-overlay">
                     <div className="countdown-content">
                         <h2>드래프트가 완료되었습니다.</h2>
+                        <p style={{ marginTop: '1rem', fontSize: '1.2rem', opacity: 0.9 }}>
+                            3초 후 채팅방으로 이동합니다...
+                        </p>
                     </div>
                 </div>
             )}
-            
+
             {/* 경고 메시지 오버레이 */}
             {showWarningMessage && (
                 <div className="warning-overlay">
@@ -1044,15 +1539,19 @@ export default function Draft() {
                     </div>
                 </div>
             )}
-            
+
             <header className="header">
                 <div className="logo">Fantasy11</div>
-                <button className="cancel-btn" onClick={() => navigate('/chatroom')}>
+                <button
+                    className="cancel-btn"
+                    disabled={!chatRoomId}
+                    onClick={() => navigate(`/chatroom/${chatRoomId}`)}
+                >
                     👉 채팅방 이동 (개발용)
                 </button>
                 <div className="draft-info">
                     <span>라운드 2/11</span>
-                    <div className="timer">{formatTime(draftTime)}</div>
+                    <div className="timer">{formatDraftTime(draftTime)}</div>
                     <span>
                         {currentTurnParticipant && (
                             `턴: ${!isBot(currentTurnParticipant) && currentTurnParticipant.userName && currentTurnParticipant.userName.trim() !== "" 
@@ -1067,14 +1566,85 @@ export default function Draft() {
             <div className="main-container">
                 {/* 채팅 */}
                 <div className="section chat-section">
-                    <h3 className="section-title">채팅</h3>
-                    <div className="chat-messages" ref={chatBoxRef}>
-                        {chatList.map((chat, i) => (
-                            <div key={i} className="chat-message">
-                                <div className="chat-user">{chat.user}</div>
-                                <div className="chat-text">{chat.message}</div>
-                            </div>
-                        ))}
+                    <div className="section-title">
+                        채팅
+                        {unreadCount > 0 && <span className="unread-count">미읽음 {unreadCount}</span>}
+                        {loading && <span className="loading-indicator"> 로딩중...</span>}
+                    </div>
+
+                    {/* 채팅 검색 영역 */}
+                    <div className="chat-search-container">
+                        <input
+                            type="text"
+                            className="chat-search-input"
+                            value={searchQuery}
+                            onChange={(e) => setSearchQuery(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter') {
+                                    e.preventDefault();
+                                    handleChatSearch();
+                                }
+                            }}
+                            placeholder="채팅 메시지 검색..."
+                        />
+                        <button
+                            className="chat-search-btn"
+                            onClick={handleChatSearch}
+                            disabled={isSearching || !searchQuery.trim()}
+                        >
+                            {isSearching ? '검색중...' : '🔍'}
+                        </button>
+                        {showSearchResults && (
+                            <button
+                                className="chat-search-clear"
+                                onClick={clearSearch}
+                                title="검색 결과 지우기"
+                            >
+                                ✕
+                            </button>
+                        )}
+                    </div>
+                    <div className="chat-messages" ref={chatRef}>
+                        {showSearchResults ? (
+                            /* 검색 결과 표시 */
+                            <>
+                                <div className="search-results-header">
+                                    검색 결과: "{searchQuery}" ({searchResults.length}건)
+                                </div>
+                                {searchResults.length > 0 ? (
+                                    searchResults.map((msg) => (
+                                        <div key={msg.id} className={`chat-message search-result ${msg.type === 'ALERT' ? 'alert-message' : ''}`}>
+                                            <div className="chat-user">{msg.user}</div>
+                                            <div className="chat-text">{msg.text}</div>
+                                            <div className="chat-time">{msg.time}</div>
+                                        </div>
+                                    ))
+                                ) : (
+                                    <div className="no-search-results">
+                                        검색 결과가 없습니다.
+                                    </div>
+                                )}
+                            </>
+                        ) : (
+                            /* 일반 채팅 메시지 표시 */
+                            <>
+                                {hasMore && (
+                                    <div ref={loadMoreRef} className="load-more-trigger">
+                                        {loading && <div className="loading-message">이전 메시지를 불러오는 중...</div>}
+                                    </div>
+                                )}
+                                {!hasMore && chatList.length > 0 && (
+                                    <div className="chat-end-message">채팅의 시작입니다.</div>
+                                )}
+                                {chatList.map((msg) => (
+                                    <div key={msg.id} className={`chat-message ${msg.type === 'ALERT' ? 'alert-message' : ''}`}>
+                                        <div className="chat-user">{msg.user}</div>
+                                        <div className="chat-text">{msg.text}</div>
+                                        <div className="chat-time">{msg.time}</div>
+                                    </div>
+                                ))}
+                            </>
+                        )}
                     </div>
                     <div className="chat-input-container">
                         <input
@@ -1082,11 +1652,29 @@ export default function Draft() {
                             className="chat-input"
                             value={message}
                             onChange={(e) => setMessage(e.target.value)}
-                            onKeyPress={handleKeyPress}
-                            placeholder="메시지를 입력하세요..."
-                            maxLength={100}
+                            onCompositionStart={() => setIsComposing(true)}
+                            onCompositionEnd={(e) => {
+                                setMessage(e.currentTarget.value);
+                                setIsComposing(false);
+                            }}
+                            onKeyDown={(e) => {
+                                const composing = isComposing || e.nativeEvent.isComposing;
+                                if (e.key === 'Enter' && !e.shiftKey) {
+                                    if (composing) return;
+                                    e.preventDefault();
+                                    handleSendMessage();
+                                }
+                            }}
+                            placeholder={isConnected ? "메시지를 입력하세요..." : "연결 중..."}
+                            disabled={!isConnected}
                         />
-                        <button className="chat-send" onClick={handleSend}>전송</button>
+                        <button
+                            className="chat-send"
+                            onClick={handleSendMessage}
+                            disabled={!isConnected || !message.trim()}
+                        >
+                            전송
+                        </button>
                     </div>
                 </div>
 
@@ -1104,11 +1692,11 @@ export default function Draft() {
                                 <option value="">선택</option>
                                 {elementTypes.map(elementType => (
                                     <option key={elementType.id} value={elementType.id}
-                                        data-squad-min-play={elementType.squadMinPlay} 
+                                        data-squad-min-play={elementType.squadMinPlay}
                                         data-squad-max-play={elementType.squadMaxPlay}
                                     >
-                                        {elementType.krName && elementType.krName.trim() !== '' 
-                                            ? elementType.krName 
+                                        {elementType.krName && elementType.krName.trim() !== ''
+                                            ? elementType.krName
                                             : elementType.pluralName}
                                     </option>
                                 ))}
@@ -1133,26 +1721,26 @@ export default function Draft() {
                     </div>
                     <div className="player-list">
                         {/* 로딩 중일 때 */}
-                        {loading && (
+                        {playersLoading && (
                             <div className="loading-message">선수 데이터를 불러오는 중...</div>
                         )}
-                        
+
                         {/* 에러 발생시 */}
                         {error && (
                             <div className="error-message">
                                 선수 데이터를 불러오는데 실패했습니다: {error}
                             </div>
                         )}
-                        
+
                         {/* 선수 목록 */}
-                        {!loading && !error && players.map((player, idx) => (
+                        {!playersLoading && !error && players.map((player, idx) => (
                             <div key={player.id || idx} className="player-item">
                                 <div className="player-position">{player.position}</div>
                                 <div className="player-photo">
                                     {player.pic ? (
-                                        <img 
-                                            src={player.pic} 
-                                            alt={player.name} 
+                                        <img
+                                            src={player.pic}
+                                            alt={player.name}
                                             onError={(e) => {
                                                 e.target.style.display = 'none';
                                             }}
@@ -1168,7 +1756,7 @@ export default function Draft() {
                                 <button
                                     className="select-btn"
                                     disabled={
-                                        myPlayerCount >= 11 || 
+                                        myPlayerCount >= 11 ||
                                         !isPlayerSelectable(player.status) ||
                                         draftCompleted ||
                                         isSelectingPlayer ||
@@ -1183,7 +1771,7 @@ export default function Draft() {
                                     {selectedPlayerIds.includes(player.id) ? '선택됨' :
                                      isSelectingPlayer ? '선택 중...' : '선택'}
                                 </button>
-                                
+
                                 {/* hidden 데이터들 (화면에는 보이지 않음) */}
                                 <div style={{ display: 'none' }}>
                                     <span data-id={player.id}></span>
@@ -1209,13 +1797,13 @@ export default function Draft() {
                             {participantLoading && (
                                 <div className="loading-message">참가자 정보를 불러오는 중...</div>
                             )}
-                            
+
                             {participantError && (
                                 <div className="error-message">
                                     참가자 정보를 불러오는데 실패했습니다: {participantError}
                                 </div>
                             )}
-                            
+
                             {!participantLoading && !participantError && participants.map((participant, idx) => {
                                 const participantIsBot = isBot(participant);
                                 const displayName = participantIsBot
@@ -1227,8 +1815,8 @@ export default function Draft() {
                                 const pickCount = participantPickCounts[participant.participantId] || 0;
 
                                 return (
-                                    <div 
-                                        key={participant.participantId} 
+                                    <div
+                                        key={participant.participantId}
                                         className={`user-card ${draftStarted && !draftCompleted && idx === currentTurnIndex ? 'active' : ''} ${participantIsBot ? 'bot-card' : ''} ${selectedParticipantId === participant.participantId ? 'selected' : ''}`}
                                         onClick={() => handleParticipantCardClick(participant.participantId)}
                                         style={{ cursor: 'pointer' }}
@@ -1242,7 +1830,7 @@ export default function Draft() {
                                             {draftStarted && !draftCompleted && idx === currentTurnIndex && ' (현재 턴)'}
                                             {participantIsBot && draftStarted && !draftCompleted && idx === currentTurnIndex && ' (선택 중...)'}
                                         </div>
-                                        
+
                                         {/* hidden 데이터들 */}
                                         <div style={{ display: 'none' }}>
                                             <span data-participant-id={participant.participantId}></span>
@@ -1262,8 +1850,8 @@ export default function Draft() {
 
                     <div style={{ flex: 1 }}>
                         <h3 className="section-title">
-                            {selectedParticipantId ? 
-                                `선택된 참가자의 선수 (${selectedParticipantDraftedPlayers.length}/11)` : 
+                            {selectedParticipantId ?
+                                `선택된 참가자의 선수 (${selectedParticipantDraftedPlayers.length}/11)` :
                                 `내 선수 (${myPlayerCount}/11)`
                             }
                         </h3>
@@ -1271,19 +1859,19 @@ export default function Draft() {
                             {draftedPlayersLoading && (
                                 <div className="loading-message">드래프트된 선수 정보를 불러오는 중...</div>
                             )}
-                            
+
                             {draftedPlayersError && (
                                 <div className="error-message">
                                     드래프트된 선수 정보를 불러오는데 실패했습니다: {draftedPlayersError}
                                 </div>
                             )}
-                            
+
                             {!draftedPlayersLoading && !draftedPlayersError && selectedParticipantDraftedPlayers.length === 0 && (
                                 <div className="no-players-message">
                                     {selectedParticipantId ? '아직 선택된 선수가 없습니다.' : '참가자를 클릭하여 선수를 확인하세요.'}
                                 </div>
                             )}
-                            
+
                             {!draftedPlayersLoading && !draftedPlayersError && selectedParticipantDraftedPlayers.map((draftedPlayer, idx) => (
                                 <div key={idx} className="my-player-item">
                                     <div className="my-player-position">
@@ -1291,8 +1879,8 @@ export default function Draft() {
                                     </div>
                                     <div className="my-player-photo">
                                         {draftedPlayer.playerPic ? (
-                                            <img 
-                                                src={draftedPlayer.playerPic} 
+                                            <img
+                                                src={draftedPlayer.playerPic}
                                                 alt={draftedPlayer.playerKrName || draftedPlayer.playerWebName}
                                                 onError={(e) => {
                                                     e.target.style.display = 'none';
@@ -1303,11 +1891,11 @@ export default function Draft() {
                                         )}
                                     </div>
                                     <div className="my-player-name">
-                                        {draftedPlayer.playerKrName && draftedPlayer.playerKrName.trim() !== '' 
-                                            ? draftedPlayer.playerKrName 
+                                        {draftedPlayer.playerKrName && draftedPlayer.playerKrName.trim() !== ''
+                                            ? draftedPlayer.playerKrName
                                             : draftedPlayer.playerWebName}
                                     </div>
-                                    
+
                                     {/* hidden 데이터들 (화면에는 보이지 않음) */}
                                     <div style={{ display: 'none' }}>
                                         <span data-participant-id={draftedPlayer.participantId}></span>

--- a/src/pages/Draft.jsx
+++ b/src/pages/Draft.jsx
@@ -11,49 +11,48 @@ import axios from 'axios';
 
 // axiosInstance 직접 생성 (동적 토큰 처리)
 const axiosInstance = axios.create({
-    baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
 });
-
-// WebSocket URL 처리 (로컬/배포 환경 대응)
-const getWebSocketUrl = () => {
-    const wsUrl = import.meta.env.VITE_API_WS_URL || 'ws://localhost:8080';
-
-    // 배포 환경에서는 wss://가 설정되어 있을 것이므로 그대로 사용
-    // 로컬 환경에서는 ws://를 http://로 변환
-    return wsUrl
-    .replace(/\/$/, '')
-    .replace(/^wss:\/\//, 'https://')
-    .replace(/^ws:\/\//, 'http://');
-};
-
-const SOCKJS_ORIGIN = getWebSocketUrl();
 
 // 요청 인터셉터 추가
 axiosInstance.interceptors.request.use(
     (config) => {
-        const token = localStorage.getItem('accessToken');
-        if (token) {
-            config.headers['Authorization'] = `Bearer ${token}`;
-        }
-        return config;
+      const token = localStorage.getItem('accessToken');
+      if (token) {
+        config.headers['Authorization'] = `Bearer ${token}`;
+      }
+      return config;
     },
     (error) => {
-        return Promise.reject(error);
+      return Promise.reject(error);
     }
 );
 
+// WebSocket URL 처리 (로컬/배포 환경 대응)
+const getWebSocketUrl = () => {
+  const wsUrl = import.meta.env.VITE_API_WS_URL || 'ws://localhost:8080';
+
+  // 배포 환경에서는 wss://가 설정되어 있을 것이므로 그대로 사용
+  // 로컬 환경에서는 ws://를 http://로 변환
+  return wsUrl
+  .replace(/\/$/, '')
+  .replace(/^wss:\/\//, 'https://')
+  .replace(/^ws:\/\//, 'http://');
+};
+
+const SOCKJS_ORIGIN = getWebSocketUrl();
+
 export default function Draft() {
-    const [draftTime, setDraftTime] = useState(45);
+    const [draftTime, setDraftTime] = useState(60); // 1. 45초 -> 60초로 변경
     const [myPlayerCount, setMyPlayerCount] = useState(2);
+
+    // 채팅 관련 상태 (ChatRoom.jsx 패턴 적용)
     const [chatList, setChatList] = useState([]);
     const [message, setMessage] = useState('');
     const [isComposing, setIsComposing] = useState(false);
-
-    // 무한스크롤 관련 상태
-    const [hasMore, setHasMore] = useState(true);
-    const [loading, setLoading] = useState(false);
-    const [nextCursor, setNextCursor] = useState(null);
-    const [isInitialLoad, setIsInitialLoad] = useState(true);
+    const [isConnected, setIsConnected] = useState(false);
+    const [currentUser, setCurrentUser] = useState(null);
+    const [chatRoomId, setChatRoomId] = useState(null); // Draft용 채팅방 ID
 
     // 채팅 검색 관련 상태
     const [searchQuery, setSearchQuery] = useState('');
@@ -61,20 +60,17 @@ export default function Draft() {
     const [isSearching, setIsSearching] = useState(false);
     const [showSearchResults, setShowSearchResults] = useState(false);
 
-    // 사용자 정보
-    const [currentUser, setCurrentUser] = useState(null);
-
-    // 채팅방 ID (draft ID와 다름)
-    const [chatRoomId, setChatRoomId] = useState(null);
+    // 채팅 히스토리 무한스크롤 관련 상태
+    const [hasMore, setHasMore] = useState(true);
+    const [loading, setLoading] = useState(false);
+    const [nextCursor, setNextCursor] = useState(null);
+    const [isInitialLoad, setIsInitialLoad] = useState(true);
 
     // 읽음 표시 관련 상태
     const [lastReadMessageId, setLastReadMessageId] = useState(null);
     const [unreadCount, setUnreadCount] = useState(0);
-
-    // WebSocket 연결 상태
-    const [isConnected, setIsConnected] = useState(false);
     const [players, setPlayers] = useState([]); // 백엔드에서 받아온 선수 데이터
-    const [playersLoading, setPlayersLoading] = useState(true); // 선수 로딩 상태
+    const [playersLoading, setPlayersLoading] = useState(true); // 선수 데이터 로딩 상태
     const [error, setError] = useState(null); // 에러 상태
     const [elementTypes, setElementTypes] = useState([]); // 포지션 타입 데이터
     const [searchParams, setSearchParams] = useState({
@@ -107,915 +103,697 @@ export default function Draft() {
     const [draftedPlayersLoading, setDraftedPlayersLoading] = useState(false); // 드래프트된 선수 로딩 상태
     const [draftedPlayersError, setDraftedPlayersError] = useState(null); // 드래프트된 선수 에러 상태
 
-    const chatBoxRef = useRef(null);
-    const chatRef = useRef(null);
+    // 3. 선수 선택 알림 메시지 상태 추가
+    const [playerSelectMessage, setPlayerSelectMessage] = useState('');
+    const [showPlayerSelectMessage, setShowPlayerSelectMessage] = useState(
+        false);
 
-    // 무한스크롤 감지를 위한 IntersectionObserver
-    const { ref: loadMoreRef, inView } = useInView({
-        threshold: 0,
-        rootMargin: '100px 0px',
-    });
+    // 2. 스네이크 드래프트 관련 상태 추가
+    const [currentRound, setCurrentRound] = useState(1); // 현재 라운드
+    const [isReverseRound, setIsReverseRound] = useState(false); // 역순 라운드 여부
+
+    const chatBoxRef = useRef(null);
     const navigate = useNavigate();
-    const { draftId } = useParams(); // URL에서 draftId 파라미터 가져오기
+    const {draftId} = useParams(); // URL에서 draftId 파라미터 가져오기
     const stompClientRef = useRef(null); // 드래프트용 WebSocket
     const chatStompClientRef = useRef(null); // 채팅용 WebSocket
     const autoSelectTimeoutRef = useRef(null);
     const retryTimeoutRef = useRef(null);
 
+    // 채팅 무한스크롤 관련 ref
+    const {ref: loadMoreRef, inView} = useInView({
+        threshold: 0,
+        rootMargin: '100px 0px',
+    });
+
     // JWT 토큰 가져오기
     const getAuthToken = () => {
-        return localStorage.getItem('accessToken') || sessionStorage.getItem('accessToken');
+        return localStorage.getItem('accessToken') || sessionStorage.getItem(
+            'accessToken');
     };
 
     // 현재 사용자 정보 가져오기
     const fetchCurrentUser = async () => {
         try {
             const response = await axiosInstance.get('/api/user/me');
-            setCurrentUser(response.data);
+            console.log('사용자 정보 응답:', response.data);
+            // API는 UserMeResponse(id, email, name) 구조
+            setCurrentUser({
+                id: response.data.id,
+                email: response.data.email,
+                name: response.data.name
+            });
         } catch (error) {
-            console.error('사용자 정보 로드 실패:', error);
+            console.error('사용자 정보 로드 실패:', error.response?.data);
             // 임시 사용자 정보 설정
             setCurrentUser({
                 id: localStorage.getItem('userId') || 'test-user',
-                email: localStorage.getItem('userEmail') || 'test@gmail.com'
+                email: localStorage.getItem('userEmail') || 'test@gmail.com',
+                name: localStorage.getItem('userName') || 'Test User'
             });
         }
     };
 
-    // Draft.jsx
-    const fetchChatRoomId = async () => {
-        try {
-            console.log('🔍 채팅방 ID 조회 시작, draftId:', draftId);
-            // 1) 드래프트로 채팅방 조회
-            const { data } = await axiosInstance.get(`/api/chat-rooms/by-draft/${draftId}`);
-            console.log('✅ 채팅방 조회 성공:', data);
-            setChatRoomId(data.id);
-            return data.id;
-        } catch (error) {
-            console.error('❌ Chat Room ID 조회 실패:', error?.response?.status, error?.message);
-            console.error('❌ 에러 세부 정보:', error?.response?.data);
+        // 드래프트 기반 채팅방 생성 및 연결
+        const createOrGetChatRoom = async () => {
+            try {
+                // 먼저 기존 채팅방이 있는지 확인
+                const getChatRoomResponse = await axiosInstance.get(
+                    `/api/chat-rooms/by-draft/${draftId}`);
+                console.log('채팅방 조회 응답:', getChatRoomResponse.data);
 
-            // 2) 404면 채팅방을 생성(백엔드 스펙에 맞게 URL/바디 조정)
-            if (error?.response?.status === 404) {
-                try {
-                    console.log('📝 채팅방 생성 시도, draftId:', draftId);
-                    // (A안) POST /api/chat-rooms  { draftId }
-                    const { data: created } = await axiosInstance.post('/api/chat-rooms', { draftId });
-                    console.log('✅ 채팅방 생성 성공:', created);
-                    setChatRoomId(created.id);
-                    return created.id;
-                } catch (e2) {
-                    console.error('❌ 채팅방 생성 실패:', e2?.response?.status, e2?.message);
-                    console.error('❌ 생성 에러 세부 정보:', e2?.response?.data);
+                // API는 ChatRoom 객체를 직접 반환하므로 .id 사용
+                const roomId = getChatRoomResponse.data.id;
+                setChatRoomId(roomId);
+                console.log('기존 채팅방 연결:', roomId);
+                return roomId;
+            } catch (error) {
+                console.log('채팅방 조회 실패:', error.response?.status,
+                    error.response?.data);
+                // 404 오류인 경우 새로 생성
+                if (error.response?.status === 404) {
+                    try {
+                        const createResponse = await axiosInstance.post(
+                            '/api/chat-rooms', {
+                                draftId: draftId
+                            });
+                        console.log('채팅방 생성 응답:', createResponse.data);
 
-                    // (B안) 만약 생성 엔드포인트가 /api/chat-rooms/by-draft/{draftId} POST 라면:
-                    // const { data: created } = await axiosInstance.post(`/api/chat-rooms/by-draft/${draftId}`);
-
-                    console.error('💥 채팅방 생성 실패 - 채팅 기능 비활성화');
-                    setChatRoomId(null);
+                        // API는 ChatRoom 객체를 직접 반환하므로 .id 사용
+                        const roomId = createResponse.data.id;
+                        setChatRoomId(roomId);
+                        console.log('새로운 채팅방 생성:', roomId);
+                        return roomId;
+                    } catch (createError) {
+                        console.error('채팅방 생성 실패:', createError.response?.data);
+                        return null;
+                    }
+                } else {
+                    console.error('채팅방 조회 실패:', error.response?.data);
                     return null;
                 }
             }
-
-            console.error('💥 채팅방 조회/생성 모두 실패, null 반환');
-            return null;
-        }
-    };
-
-    // 시간 포맷
-    const formatTime = (timestamp) => {
-        const date = new Date(timestamp);
-        return date.toLocaleTimeString('ko-KR', {
-            hour: 'numeric',
-            minute: '2-digit',
-            hour12: true
-        });
-    };
-
-    // 메시지 포맷 변환 (수정됨 - 사용자 이름 결정 로직 개선)
-    const formatMessage = useCallback((item) => {
-        let userName = '시스템';
-        if (item.type === 'ALERT' || item.type === 'SYSTEM') {
-            userName = '⚽ 알림';
-        } else if (item.userId) {
-            // 현재 사용자인지 먼저 확인
-            if (currentUser && item.userId === currentUser.id) {
-                userName = currentUser.email;
-            } else {
-                // 참가자 목록에서 사용자 정보 찾기
-                const participant = participants.find(p => p.userId === item.userId);
-                if (participant && participant.userEmail) {
-                    userName = participant.userEmail;
-                } else {
-                    // 참가자 목록에 없는 사용자는 기본값으로 처리
-                    userName = '알 수 없는 사용자';
-                }
-            }
-        }
-
-        return {
-            id: item.id,
-            user: userName,
-            text: item.content,
-            time: formatTime(item.createdAt),
-            type: item.type,
-            userId: item.userId
-        };
-    }, [currentUser, participants]);
-
-    // 채팅 히스토리 초기 로드 (최신 메시지부터)
-    const loadInitialHistory = async () => {
-        if (loading) return;
-        setLoading(true);
-
-        try {
-            const response = await axiosInstance.get(`/api/chat-rooms/${chatRoomId}/messages`, {
-                params: { limit: 20 }
-            });
-
-            const { items, nextCursor: cursor, hasMore: more } = response.data;
-
-            setChatList(items.map(formatMessage));
-            setNextCursor(cursor);
-            setHasMore(more);
-            setIsInitialLoad(false);
-
-            // 초기 로드 완료 후 즉시 맨 아래로 스크롤
-            requestAnimationFrame(() => {
-                if (chatRef.current) {
-                    chatRef.current.scrollTop = chatRef.current.scrollHeight;
-                }
-            });
-
-        } catch (error) {
-            console.error('채팅 히스토리 초기 로드 실패:', error);
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    // 이전 메시지 로드 (무한스크롤)
-    const loadMoreMessages = async () => {
-        if (loading || !nextCursor || !hasMore) return;
-        setLoading(true);
-
-        try {
-            const response = await axiosInstance.get(`/api/chat-rooms/${chatRoomId}/messages/before`, {
-                params: {
-                    cursor: nextCursor,
-                    limit: 20
-                }
-            });
-
-            const { items, nextCursor: cursor, hasMore: more } = response.data;
-
-            const currentScrollHeight = chatRef.current?.scrollHeight || 0;
-
-            setChatList(prev => [...items.map(formatMessage), ...prev]);
-            setNextCursor(cursor);
-            setHasMore(more);
-
-            setTimeout(() => {
-                if (chatRef.current) {
-                    const newScrollHeight = chatRef.current.scrollHeight;
-                    const heightDiff = newScrollHeight - currentScrollHeight;
-                    chatRef.current.scrollTop = chatRef.current.scrollTop + heightDiff;
-                }
-            }, 50);
-
-        } catch (error) {
-            console.error('이전 메시지 로드 실패:', error);
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    // 채팅 검색 함수
-    const searchChatMessages = async (query) => {
-        if (!query.trim()) {
-            setSearchResults([]);
-            setShowSearchResults(false);
-            return;
-        }
-
-        setIsSearching(true);
-        try {
-            const response = await axiosInstance.get(`/api/chat-rooms/${chatRoomId}/search`, {
-                params: {
-                    q: query.trim(),
-                    limit: 20
-                }
-            });
-
-            const { items } = response.data;
-            setSearchResults(items.map(formatMessage));
-            setShowSearchResults(true);
-        } catch (error) {
-            console.error('채팅 검색 실패:', error);
-            setSearchResults([]);
-            setShowSearchResults(false);
-        } finally {
-            setIsSearching(false);
-        }
-    };
-
-    // 채팅 검색 실행
-    const handleChatSearch = () => {
-        searchChatMessages(searchQuery);
-    };
-
-    // 검색 초기화
-    const clearSearch = () => {
-        setSearchQuery('');
-        setSearchResults([]);
-        setShowSearchResults(false);
-    };
-
-    // 읽음 상태 조회
-    const fetchReadState = async () => {
-        try {
-            const response = await axiosInstance.get(`/api/chat-rooms/${chatRoomId}/read-state`);
-            setLastReadMessageId(response.data.lastReadMessageId);
-            setUnreadCount(response.data.unreadCount);
-        } catch (error) {
-            console.error('읽음 상태 조회 실패:', error);
-        }
-    };
-
-    // 읽음 표시 업데이트
-    const markReadUpTo = async (messageId) => {
-        try {
-            const response = await axiosInstance.post(`/api/chat-rooms/${chatRoomId}/read-state`, {
-                messageId: messageId
-            });
-            setUnreadCount(response.data.unreadCount);
-            setLastReadMessageId(messageId);
-        } catch (error) {
-            console.error('읽음 표시 업데이트 실패:', error);
-        }
-    };
-
-    // 읽음 표시 업데이트 디바운스
-    const debouncedMarkRead = useCallback(
-        debounce((messageId) => {
-            markReadUpTo(messageId);
-        }, 1000),
-        [chatRoomId]);
-
-    // draftId 확인을 위한 로그
-    // 무한스크롤 로드 디바운스
-    const debouncedLoadMore = useCallback(
-        debounce(() => {
-            if (hasMore && !loading && !isInitialLoad) {
-                loadMoreMessages();
-            }
-        }, 300),
-        [hasMore, loading, nextCursor, isInitialLoad]
-    );
-
-    // 무한스크롤 트리거
-    useEffect(() => {
-        if (inView && hasMore && !loading && !isInitialLoad) {
-            debouncedLoadMore();
-        }
-    }, [inView, hasMore, loading, isInitialLoad, debouncedLoadMore]);
-
-    // 채팅 WebSocket 연결 (수정됨 - 사용자 이름 처리 개선)
-    const connectChatWebSocket = useCallback(() => {
-        if (chatStompClientRef.current?.connected || !chatRoomId) return;
-
-        const token = getAuthToken();
-        if (!token) {
-            console.error('채팅 인증 토큰이 없습니다.');
-            setIsConnected(false);
-            return;
-        }
-
-        console.log('=== 채팅 WebSocket 연결 시도 ===');
-        console.log('draftId:', draftId);
-        console.log('chatRoomId:', chatRoomId);
-        console.log('token 존재:', !!token);
-        console.log('wsUrl:', SOCKJS_ORIGIN);
-
-        try {
-            const socket = new SockJS(`${SOCKJS_ORIGIN}/ws`);
-            const chatStompClient = new Client({
-                webSocketFactory: () => socket,
-                connectHeaders: {
-                    'Authorization': `Bearer ${token}`
-                },
-                debug: (str) => {
-                    console.log('Chat STOMP Debug:', str);
-                },
-                onConnect: (frame) => {
-                    console.log('✅ 채팅 WebSocket 연결 성공:', frame);
-                    console.log('채팅방 구독 시도:', `/topic/chat/${chatRoomId}`);
-                    setIsConnected(true);
-
-                    // 채팅방 구독 (실제 chatRoomId 사용)
-                    const subscription = chatStompClient.subscribe(`/topic/chat/${chatRoomId}`, (message) => {
-                        console.log('✅ 채팅 메시지 수신:', message.body);
-                        const newMessage = JSON.parse(message.body);
-
-                        // 사용자 이름 결정 (formatMessage와 동일한 로직)
-                        let userName = '시스템';
-                        if (newMessage.type === 'ALERT' || newMessage.type === 'SYSTEM') {
-                            userName = '⚽ 알림';
-                        } else if (newMessage.userId) {
-                            if (currentUser && newMessage.userId === currentUser.id) {
-                                userName = currentUser.email;
-                            } else {
-                                // 참가자 목록에서 사용자 정보 찾기
-                                const participant = participants.find(p => p.userId === newMessage.userId);
-                                if (participant && participant.userEmail) {
-                                    userName = participant.userEmail;
-                                } else {
-                                    userName = '알 수 없는 사용자';
-                                }
-                            }
-                        }
-
-                        const formattedMessage = {
-                            id: newMessage.id || Date.now().toString(),
-                            user: userName,
-                            text: newMessage.content,
-                            time: formatTime(newMessage.createdAt || new Date()),
-                            type: newMessage.type,
-                            userId: newMessage.userId
-                        };
-
-                        setChatList(prev => {
-                            // 중복 메시지 방지: 같은 ID의 메시지가 이미 있는지 확인
-                            const isDuplicate = prev.some(msg => msg.id === formattedMessage.id);
-                            if (isDuplicate) {
-                                console.log('중복 메시지 무시:', formattedMessage.id);
-                                return prev;
-                            }
-
-                            const newList = [...prev, formattedMessage];
-
-                            setTimeout(() => {
-                                if (chatRef.current) {
-                                    chatRef.current.scrollTop = chatRef.current.scrollHeight;
-                                }
-                            }, 100);
-
-                            return newList;
-                        });
-                    });
-
-                    console.log('채팅 구독 완료:', subscription);
-                },
-                onDisconnect: (frame) => {
-                    console.log('채팅 WebSocket 연결 해제:', frame);
-                    setIsConnected(false);
-                },
-                onStompError: (frame) => {
-                    console.error('채팅 STOMP 오류:', frame);
-                    setIsConnected(false);
-
-                    setTimeout(() => {
-                        if (!chatStompClientRef.current?.connected) {
-                            console.log('채팅 재연결 시도...');
-                            connectChatWebSocket();
-                        }
-                    }, 3000);
-                },
-                onWebSocketError: (error) => {
-                    console.error('채팅 WebSocket 오류:', error);
-                },
-                reconnectDelay: 5000,
-                heartbeatIncoming: 4000,
-                heartbeatOutgoing: 4000
-            });
-
-            chatStompClient.activate();
-            chatStompClientRef.current = chatStompClient;
-            console.log('채팅 STOMP 클라이언트 활성화됨');
-        } catch (error) {
-            console.error('채팅 WebSocket 연결 실패:', error);
-            setIsConnected(false);
-        }
-    }, [draftId, chatRoomId, currentUser, participants]);
-
-    useEffect(() => {
-        if (!draftId) {
-            console.error('draftId is missing from URL parameters');
-            return;
-        }
-        (async () => {
-            await fetchCurrentUser();
-            await fetchChatRoomId();  // chatRoomId 세팅
-        })();
-    }, [draftId]);
-
-    useEffect(() => {
-        if (!chatRoomId) return;
-        // 순서 중요: 히스토리/읽음 먼저, 그다음 WS
-        (async () => {
-            await loadInitialHistory();
-            await fetchReadState();
-            if (currentUser && participants.length > 0 && !isConnected) {
-                connectChatWebSocket();
-            }
-        })();
-    }, [chatRoomId, currentUser, participants]);
-
-    // 사용자 정보와 참가자 정보 로드 후 WebSocket 연결
-    useEffect(() => {
-        if (currentUser && participants.length > 0 && chatRoomId && !isConnected) {
-            connectChatWebSocket();
-        }
-    }, [currentUser, participants, chatRoomId, connectChatWebSocket]);
-
-    // 사용자 정보 또는 참가자 정보 업데이트 시 기존 메시지 다시 포맷팅
-    useEffect(() => {
-        if ((currentUser || participants.length > 0) && chatList.length > 0) {
-            setChatList(prevList =>
-                prevList.map(msg => {
-                    // 이미 포맷된 메시지에서 사용자 이름만 업데이트
-                    if (!msg.userId || msg.user === '⚽ 알림' || msg.user === '시스템') {
-                        return msg;
-                    }
-
-                    let newUserName = msg.user;
-                    if (currentUser && msg.userId === currentUser.id) {
-                        newUserName = currentUser.email;
-                    } else {
-                        const participant = participants.find(p => p.userId === msg.userId);
-                        if (participant && participant.userEmail) {
-                            newUserName = participant.userEmail;
-                        } else {
-                            newUserName = '알 수 없는 사용자';
-                        }
-                    }
-
-                    return {
-                        ...msg,
-                        user: newUserName
-                    };
-                })
-            );
-        }
-    }, [currentUser, participants]);
-
-    // 새 메시지 추가 시 스크롤 및 읽음 표시 업데이트
-    useEffect(() => {
-        if (chatRef.current && chatList.length > 0) {
-            const { scrollTop, scrollHeight, clientHeight } = chatRef.current;
-            const isNearBottom = scrollHeight - scrollTop - clientHeight < 100;
-
-            if (isNearBottom) {
-                setTimeout(() => {
-                    if (chatRef.current) {
-                        chatRef.current.scrollTop = chatRef.current.scrollHeight;
-                    }
-                }, 100);
-
-                const lastMessage = chatList[chatList.length - 1];
-                if (lastMessage && lastMessage.id !== lastReadMessageId) {
-                    debouncedMarkRead(lastMessage.id);
-                }
-            }
-        }
-    }, [chatList, lastReadMessageId, debouncedMarkRead]);
-
-    // 스크롤 이벤트로 읽음 표시 업데이트
-    useEffect(() => {
-        const handleScroll = () => {
-            if (!chatRef.current || chatList.length === 0) return;
-
-            const { scrollTop, scrollHeight, clientHeight } = chatRef.current;
-            const isNearBottom = scrollHeight - scrollTop - clientHeight < 100;
-
-            if (isNearBottom) {
-                const lastMessage = chatList[chatList.length - 1];
-                if (lastMessage && lastMessage.id !== lastReadMessageId) {
-                    debouncedMarkRead(lastMessage.id);
-                }
-            }
         };
 
-        const chatElement = chatRef.current;
-        if (chatElement) {
-            chatElement.addEventListener('scroll', handleScroll);
-            return () => chatElement.removeEventListener('scroll', handleScroll);
-        }
-    }, [chatList, lastReadMessageId, debouncedMarkRead]);
-
-    // 드래프트 완료 시 자동으로 채팅방으로 리다이렉트
-    useEffect(() => {
-        if (draftCompleted) {
-            const redirectTimer = setTimeout(() => {
-                console.log('Draft completed, redirecting to chatroom...');
-                navigate(`/chatroom/${chatRoomId}`);
-            }, 3000); // 3초 후 자동 리다이렉트
-
-            return () => clearTimeout(redirectTimer);
-        }
-    }, [draftCompleted, navigate, chatRoomId]);
-
-    // 새로고침 방지 및 창 닫기 확인 기능
-    useEffect(() => {
-        // 새로고침 방지 (F5, Ctrl+R 등)
-        const handleKeyDown = (e) => {
-            // F5 키 방지
-            if (e.key === 'F5') {
-                e.preventDefault();
-                alert('드래프트 중 새로고침은 불가합니다.');
-                return false;
+        // 시간 포맷 (채팅에서 사용)
+        const normalizeIsoToMs = (ts) => {
+            if (!ts) return null;
+            if (ts instanceof Date || typeof ts === 'number') return ts;
+            if (typeof ts === 'string') {
+                return ts.replace(
+                    /(\.[0-9]{3})[0-9]+(Z|[+\-][0-9]{2}:[0-9]{2})$/, '$1$2');
             }
-
-            // Ctrl+R (새로고침) 방지
-            if ((e.ctrlKey || e.metaKey) && e.key === 'r') {
-                e.preventDefault();
-                alert('드래프트 중 새로고침은 불가합니다.');
-                return false;
-            }
+            return ts;
         };
 
-        // beforeunload 이벤트로 창 닫기/새로고침 시도 감지
-        const handleBeforeUnload = (e) => {
-            const message = '정말로 창 닫기 하시겠습니까? 해당 드래프트방에 다시 돌아올 수 없습니다.';
-            e.preventDefault();
-            e.returnValue = message; // Chrome에서 필요
-            return message; // 다른 브라우저에서 필요
-        };
-
-        // 이벤트 리스너 등록
-        document.addEventListener('keydown', handleKeyDown);
-        window.addEventListener('beforeunload', handleBeforeUnload);
-
-        // 컴포넌트 언마운트 시 이벤트 리스너 제거
-        return () => {
-            document.removeEventListener('keydown', handleKeyDown);
-            window.removeEventListener('beforeunload', handleBeforeUnload);
-        };
-    }, []);
-
-    // Bot 판별 함수
-    const isBot = (participant) => {
-        return participant.userFlag === false &&
-            (participant.userName === null || participant.userName.trim() === "");
-    };
-
-    // 현재 사용자의 차례인지 확인하는 함수
-    const isMyTurn = () => {
-        if (!draftStarted || draftCompleted || participants.length === 0) return false;
-
-        const currentParticipant = participants[currentTurnIndex];
-        if (!currentParticipant) return false;
-
-        // Bot이 아니고 userFlag가 true인 경우 사용자의 차례
-        return !isBot(currentParticipant) && currentParticipant.userFlag === true;
-    };
-
-    // 포지션 코드 변환 함수
-    const getPositionCodeFromPluralName = (elementTypePluralName) => {
-        switch (elementTypePluralName) {
-            case 'Forwards':
-                return 'FW';
-            case 'Midfielders':
-                return 'MF';
-            case 'Defenders':
-                return 'DF';
-            case 'Goalkeepers':
-                return 'GK';
-            default:
+        const formatTime = (timestamp) => {
+            const safe = normalizeIsoToMs(timestamp);
+            const date = safe ? new Date(safe) : new Date();
+            if (isNaN(date)) return '';
+            try {
+                return date.toLocaleTimeString('ko-KR', {
+                    hour: 'numeric',
+                    minute: '2-digit',
+                    hour12: true
+                });
+            } catch {
                 return '';
-        }
-    };
+            }
+        };
 
-    // 현재 턴 참가자의 포지션별 선택된 선수 수 체크 함수
-    const checkPositionLimit = (selectedPlayer) => {
-        const currentParticipant = participants[currentTurnIndex];
-        if (!currentParticipant) return { isValid: false, message: '참가자 정보를 찾을 수 없습니다.' };
+        // 메시지 포맷 변환
+        const formatMessage = useCallback((item) => {
+            let userName = '시스템';
+            if (item.type === 'ALERT' || item.type === 'SYSTEM') {
+                userName = '⚽ 알림';
+            } else if (item.userId) {
+                if (currentUser && item.userId === currentUser.id) {
+                    userName = currentUser.email;
+                } else {
+                    // 참가자 리스트에서 사용자 정보 찾기 (추후 수정 가능)
+                    userName = item.userEmail || '알 수 없는 사용자';
+                }
+            }
 
-        // 현재 참가자가 선택한 선수들 필터링
-        const currentParticipantDraftedPlayers = draftedPlayers.filter(
-            player => player.participantId === currentParticipant.participantId
-        );
-
-        // 현재 선택하려는 포지션과 같은 포지션의 선수들 필터링
-        const samePositionPlayers = currentParticipantDraftedPlayers.filter(
-            player => player.elementTypeId === selectedPlayer.elementTypeId
-        );
-
-        // 해당 포지션의 최대 선택 가능 수 찾기
-        const elementType = elementTypes.find(
-            type => type.id === selectedPlayer.elementTypeId
-        );
-
-        if (!elementType) {
-            return { isValid: false, message: '포지션 정보를 찾을 수 없습니다.' };
-        }
-
-        const maxPlayCount = elementType.squadMaxPlay;
-        const currentCount = samePositionPlayers.length;
-
-        console.log(`Position check for ${selectedPlayer.elementTypePluralName}:`, {
-            currentCount,
-            maxPlayCount,
-            elementTypeId: selectedPlayer.elementTypeId,
-            participantId: currentParticipant.participantId
-        });
-
-        if (currentCount >= maxPlayCount) {
             return {
-                isValid: false,
-                message: `${selectedPlayer.elementTypePluralName} 포지션은 최대 ${maxPlayCount}명까지 선택할 수 있습니다.`
+                id: item.id,
+                user: userName,
+                text: item.content,
+                time: formatTime(item.createdAt),
+                type: item.type,
+                userId: item.userId
             };
-        }
+        }, [currentUser]);
 
-        return { isValid: true, message: '' };
-    };
+        // draftId 확인을 위한 로그
+        useEffect(() => {
+            console.log('Current draftId from URL:', draftId);
+            if (!draftId) {
+                console.error('draftId is missing from URL parameters');
+            }
+        }, [draftId]);
 
-    // 드래프트된 선수 리스트 fetch
-    useEffect(() => {
-        const fetchDraftedPlayers = async () => {
-            try {
-                setDraftedPlayersLoading(true);
-
-                const accessToken = localStorage.getItem("accessToken");
-
-                const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/api/draft/${draftId}/allPlayers`, {
-                    method: "GET",
-                    headers: {
-                        "Content-Type": "application/json",
-                        "Authorization": `Bearer ${accessToken}`
-                    }
-                });
-
-                if (!response.ok) {
-                    throw new Error(`HTTP error! status: ${response.status}`);
+        // 새로고침 방지 및 창 닫기 확인 기능
+        useEffect(() => {
+            // 새로고침 방지 (F5, Ctrl+R 등)
+            const handleKeyDown = (e) => {
+                // F5 키 방지
+                if (e.key === 'F5') {
+                    e.preventDefault();
+                    alert('드래프트 중 새로고침은 불가합니다.');
+                    return false;
                 }
 
-                const draftedPlayersData = await response.json();
-                setDraftedPlayers(draftedPlayersData);
+                // Ctrl+R (새로고침) 방지
+                if ((e.ctrlKey || e.metaKey) && e.key === 'r') {
+                    e.preventDefault();
+                    alert('드래프트 중 새로고침은 불가합니다.');
+                    return false;
+                }
+            };
 
-                // 드래프트된 선수 ID들을 selectedPlayerIds에 추가
-                const playerIds = draftedPlayersData.map(player => player.playerId);
-                setSelectedPlayerIds(playerIds);
+            // beforeunload 이벤트로 창 닫기/새로고침 시도 감지
+            const handleBeforeUnload = (e) => {
+                const message = '정말로 창 닫기 하시겠습니까? 해당 드래프트방에 다시 돌아올 수 없습니다.';
+                e.preventDefault();
+                e.returnValue = message; // Chrome에서 필요
+                return message; // 다른 브라우저에서 필요
+            };
 
-                setDraftedPlayersError(null);
+            // 이벤트 리스너 등록
+            document.addEventListener('keydown', handleKeyDown);
+            window.addEventListener('beforeunload', handleBeforeUnload);
 
-                console.log('Drafted players loaded:', draftedPlayersData.length, 'players');
+            // 컴포넌트 언마운트 시 이벤트 리스너 제거
+            return () => {
+                document.removeEventListener('keydown', handleKeyDown);
+                window.removeEventListener('beforeunload', handleBeforeUnload);
+            };
+        }, []);
 
-            } catch (err) {
-                console.error("드래프트된 선수 데이터를 가져오는데 실패했습니다:", err);
-                setDraftedPlayersError(err.message);
-            } finally {
-                setDraftedPlayersLoading(false);
+        // Bot 판별 함수
+        const isBot = (participant) => {
+            return participant.userFlag === false &&
+                (participant.userName === null || participant.userName.trim()
+                    === "");
+        };
+
+        // 2. 스네이크 드래프트 순서 계산 함수 (수정됨)
+        const getSnakeDraftTurnIndex = (totalSelections, participantCount) => {
+            // totalSelections는 이미 선택된 선수의 수이므로, 다음 턴을 계산할 때는 그대로 사용
+            const round = Math.floor(totalSelections / participantCount) + 1;
+            const positionInRound = totalSelections % participantCount;
+
+            console.log(
+                `Snake draft calculation: totalSelections=${totalSelections}, participantCount=${participantCount}, round=${round}, positionInRound=${positionInRound}`);
+
+            let turnIndex;
+            // 홀수 라운드(1, 3, 5...)는 정순 (0, 1, 2, 3)
+            if (round % 2 === 1) {
+                turnIndex = positionInRound;
+            } else {
+                // 짝수 라운드(2, 4, 6...)는 역순 (3, 2, 1, 0)
+                turnIndex = participantCount - 1 - positionInRound;
+            }
+
+            console.log(`Snake draft result: turnIndex=${turnIndex}`);
+            return turnIndex;
+        };
+
+        // 현재 사용자의 차례인지 확인하는 함수
+        const isMyTurn = () => {
+            if (!draftStarted || draftCompleted || participants.length
+                === 0) return false;
+
+            const currentParticipant = participants[currentTurnIndex];
+            if (!currentParticipant) return false;
+
+            // Bot이 아니고 userFlag가 true인 경우 사용자의 차례
+            return !isBot(currentParticipant) && currentParticipant.userFlag
+                === true;
+        };
+
+        // 포지션 코드 변환 함수
+        const getPositionCodeFromPluralName = (elementTypePluralName) => {
+            switch (elementTypePluralName) {
+                case 'Forwards':
+                    return 'FW';
+                case 'Midfielders':
+                    return 'MF';
+                case 'Defenders':
+                    return 'DF';
+                case 'Goalkeepers':
+                    return 'GK';
+                default:
+                    return '';
             }
         };
 
-        fetchDraftedPlayers();
-    }, [draftId]);
+        // 현재 턴 참가자의 포지션별 선택된 선수 수 체크 함수
+        const checkPositionLimit = (selectedPlayer) => {
+            const currentParticipant = participants[currentTurnIndex];
+            if (!currentParticipant) return {
+                isValid: false,
+                message: '참가자 정보를 찾을 수 없습니다.'
+            };
 
-    // 참가자 카드 클릭 핸들러
-    const handleParticipantCardClick = (participantId) => {
-        setSelectedParticipantId(participantId);
-        console.log('Selected participant:', participantId);
-    };
+            // 현재 참가자가 선택한 선수들 필터링
+            const currentParticipantDraftedPlayers = draftedPlayers.filter(
+                player => player.participantId
+                    === currentParticipant.participantId
+            );
 
-    // 선택된 참가자의 드래프트된 선수들 가져오기
-    const getSelectedParticipantDraftedPlayers = () => {
-        if (!selectedParticipantId) return [];
+            // 현재 선택하려는 포지션과 같은 포지션의 선수들 필터링
+            const samePositionPlayers = currentParticipantDraftedPlayers.filter(
+                player => player.elementTypeId === selectedPlayer.elementTypeId
+            );
 
-        return draftedPlayers.filter(player => player.participantId === selectedParticipantId);
-    };
+            // 해당 포지션의 최대 선택 가능 수 찾기
+            const elementType = elementTypes.find(
+                type => type.id === selectedPlayer.elementTypeId
+            );
 
-    // 참가자 데이터 fetch
-    useEffect(() => {
-        const fetchParticipants = async () => {
-            try {
-                setParticipantLoading(true);
-
-                const accessToken = localStorage.getItem("accessToken");
-
-                const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/api/draft/${draftId}/participants`, {
-                    method: "GET",
-                    headers: {
-                        "Content-Type": "application/json",
-                        "Authorization": `Bearer ${accessToken}`
-                    }
-                });
-
-                if (!response.ok) {
-                    throw new Error(`HTTP error! status: ${response.status}`);
-                }
-
-                const participantData = await response.json();
-
-                // participantUserNumber로 정렬
-                const sortedParticipants = participantData.sort(
-                    (a, b) => a.participantUserNumber - b.participantUserNumber
-                );
-
-                setParticipants(sortedParticipants);
-
-                // 각 참가자별 선택 카운트 초기화
-                const initialCounts = {};
-                sortedParticipants.forEach(participant => {
-                    initialCounts[participant.participantId] = 0;
-                });
-                setParticipantPickCounts(initialCounts);
-
-                setParticipantError(null);
-
-                // 참가자 데이터를 성공적으로 가져오면 카운트다운 시작
-                setShowCountdown(true);
-
-                // 참가자 정보 로그 출력
-                console.log('Participants loaded:', sortedParticipants.map(p => ({
-                    id: p.participantId,
-                    userFlag: p.userFlag,
-                    userName: p.userName,
-                    isBot: isBot(p)
-                })));
-
-            } catch (err) {
-                console.error("참가자 데이터를 가져오는데 실패했습니다:", err);
-                setParticipantError(err.message);
-            } finally {
-                setParticipantLoading(false);
+            if (!elementType) {
+                return {isValid: false, message: '포지션 정보를 찾을 수 없습니다.'};
             }
+
+            const maxPlayCount = elementType.squadMaxPlay;
+            const currentCount = samePositionPlayers.length;
+
+            console.log(
+                `Position check for ${selectedPlayer.elementTypePluralName}:`, {
+                    currentCount,
+                    maxPlayCount,
+                    elementTypeId: selectedPlayer.elementTypeId,
+                    participantId: currentParticipant.participantId
+                });
+
+            if (currentCount >= maxPlayCount) {
+                return {
+                    isValid: false,
+                    message: `${selectedPlayer.elementTypePluralName} 포지션은 최대 ${maxPlayCount}명까지 선택할 수 있습니다.`
+                };
+            }
+
+            return {isValid: true, message: ''};
         };
 
-        fetchParticipants();
-    }, [draftId]);
+        // 드래프트된 선수 리스트 fetch
+        useEffect(() => {
+            const fetchDraftedPlayers = async () => {
+                try {
+                    setDraftedPlayersLoading(true);
 
-    // 드래프트 시작 카운트다운
-    useEffect(() => {
-        if (!showCountdown || draftStarted) return;
+                    const accessToken = localStorage.getItem("accessToken");
 
-        const countdownInterval = setInterval(() => {
-            setCountdown(prev => {
-                if (prev <= 1) {
-                    // 카운트다운 종료, 드래프트 시작
-                    setShowCountdown(false);
-                    setDraftStarted(true);
-                    clearInterval(countdownInterval);
-                    return 0;
+                    const response = await axiosInstance.get(
+                        `/api/draft/${draftId}/allPlayers`);
+
+                    const draftedPlayersData = response.data;
+                    setDraftedPlayers(draftedPlayersData);
+
+                    // 드래프트된 선수 ID들을 selectedPlayerIds에 추가
+                    const playerIds = draftedPlayersData.map(
+                        player => player.playerId);
+                    setSelectedPlayerIds(playerIds);
+
+                    setDraftedPlayersError(null);
+
+                    console.log('Drafted players loaded:',
+                        draftedPlayersData.length, 'players');
+
+                } catch (err) {
+                    console.error("드래프트된 선수 데이터를 가져오는데 실패했습니다:", err);
+                    setDraftedPlayersError(err.message);
+                } finally {
+                    setDraftedPlayersLoading(false);
                 }
-                return prev - 1;
+            };
+
+            fetchDraftedPlayers();
+        }, [draftId]);
+
+        // 참가자 카드 클릭 핸들러
+        const handleParticipantCardClick = (participantId) => {
+            setSelectedParticipantId(participantId);
+            console.log('Selected participant:', participantId);
+        };
+
+        // 선택된 참가자의 드래프트된 선수들 가져오기
+        const getSelectedParticipantDraftedPlayers = () => {
+            if (!selectedParticipantId) return [];
+
+            return draftedPlayers.filter(
+                player => player.participantId === selectedParticipantId);
+        };
+
+        // 참가자 데이터 fetch
+        useEffect(() => {
+            const fetchParticipants = async () => {
+                try {
+                    setParticipantLoading(true);
+
+                    const accessToken = localStorage.getItem("accessToken");
+
+                    const response = await axiosInstance.get(
+                        `/api/draft/${draftId}/participants`);
+
+                    const participantData = response.data;
+
+                    // participantUserNumber로 정렬
+                    const sortedParticipants = participantData.sort(
+                        (a, b) => a.participantUserNumber
+                            - b.participantUserNumber
+                    );
+
+                    setParticipants(sortedParticipants);
+
+                    // 각 참가자별 선택 카운트 초기화
+                    const initialCounts = {};
+                    sortedParticipants.forEach(participant => {
+                        initialCounts[participant.participantId] = 0;
+                    });
+                    setParticipantPickCounts(initialCounts);
+
+                    setParticipantError(null);
+
+                    // 참가자 데이터를 성공적으로 가져오면 카운트다운 시작
+                    setShowCountdown(true);
+
+                    // 참가자 정보 로그 출력
+                    console.log('Participants loaded:',
+                        sortedParticipants.map(p => ({
+                            id: p.participantId,
+                            userFlag: p.userFlag,
+                            userName: p.userName,
+                            isBot: isBot(p)
+                        })));
+
+                } catch (err) {
+                    console.error("참가자 데이터를 가져오는데 실패했습니다:", err);
+                    setParticipantError(err.message);
+                } finally {
+                    setParticipantLoading(false);
+                }
+            };
+
+            fetchParticipants();
+        }, [draftId]);
+
+        // 드래프트 시작 카운트다운
+        useEffect(() => {
+            if (!showCountdown || draftStarted) return;
+
+            const countdownInterval = setInterval(() => {
+                setCountdown(prev => {
+                    if (prev <= 1) {
+                        // 카운트다운 종료, 드래프트 시작
+                        setShowCountdown(false);
+                        setDraftStarted(true);
+                        clearInterval(countdownInterval);
+                        return 0;
+                    }
+                    return prev - 1;
+                });
+            }, 1000);
+
+            return () => clearInterval(countdownInterval);
+        }, [showCountdown, draftStarted]);
+
+        // 드래프트 완료 체크 함수
+        const checkDraftCompletion = (updatedPickCounts) => {
+            console.log('Checking draft completion with counts:',
+                updatedPickCounts);
+            console.log('Participants:', participants);
+
+            if (participants.length === 0) return false;
+
+            // 모든 참가자가 11명씩 선택했는지 확인
+            const allCompleted = participants.every(participant => {
+                const pickCount = updatedPickCounts[participant.participantId]
+                    || 0;
+                console.log(
+                    `Participant ${participant.participantId} (${participant.userName}): ${pickCount}/11`);
+                return pickCount >= 11;
             });
-        }, 1000);
 
-        return () => clearInterval(countdownInterval);
-    }, [showCountdown, draftStarted]);
-
-    // 드래프트 완료 체크 함수
-    const checkDraftCompletion = (updatedPickCounts) => {
-        console.log('Checking draft completion with counts:', updatedPickCounts);
-        console.log('Participants:', participants);
-
-        if (participants.length === 0) return false;
-
-        // 모든 참가자가 11명씩 선택했는지 확인
-        const allCompleted = participants.every(participant => {
-            const pickCount = updatedPickCounts[participant.participantId] || 0;
-            console.log(`Participant ${participant.participantId} (${participant.userName}): ${pickCount}/11`);
-            return pickCount >= 11;
-        });
-
-        console.log('All participants completed:', allCompleted);
-        return allCompleted;
-    };
-
-    // 선택 가능한 선수 목록 가져오기
-    const getSelectablePlayers = () => {
-        return players.filter(player =>
-            isPlayerSelectable(player.status) &&
-            !selectedPlayerIds.includes(player.id)
-        );
-    };
-
-    // Bot 자동 선택 함수
-    const performBotAutoSelect = () => {
-        const currentParticipant = participants[currentTurnIndex];
-        if (!currentParticipant || !isBot(currentParticipant)) return;
-
-        console.log(`Bot ${currentParticipant.participantId} is auto-selecting...`);
-
-        const selectablePlayers = getSelectablePlayers();
-        if (selectablePlayers.length === 0) {
-            console.log('No selectable players available for bot');
-            moveToNextTurn();
-            return;
-        }
-
-        // Bot은 포지션 제한을 고려하여 선택
-        let availablePlayer = null;
-        for (const player of selectablePlayers) {
-            const positionCheck = checkPositionLimit(player);
-            if (positionCheck.isValid) {
-                availablePlayer = player;
-                break;
-            }
-        }
-
-        if (!availablePlayer) {
-            console.log('No available players within position limits for bot');
-            moveToNextTurn();
-            return;
-        }
-
-        console.log(`Bot selecting player: ${availablePlayer.name}`);
-        handlePlayerSelect(availablePlayer, true, true); // isAutoSelect, isBot
-    };
-
-    // 사용자 시간 만료 시 자동 선택 함수 (수정됨)
-    const performUserAutoSelect = () => {
-        const currentParticipant = participants[currentTurnIndex];
-        if (!currentParticipant || isBot(currentParticipant)) return;
-
-        // 현재 참가자가 실제 사용자(data-is-user가 true)가 아닌 경우 아무것도 하지 않음
-        if (currentParticipant.userFlag !== true) {
-            console.log(`Not a real user (userFlag: ${currentParticipant.userFlag}), waiting for WebSocket response...`);
-            return; // 대기 상태 유지, 다음 턴으로 이동하지 않음, 자동 선택하지 않음
-        }
-
-        console.log(`User ${currentParticipant.participantId} time expired, sending random select request...`);
-
-        // 실제 사용자인 경우 랜덤 선택 WebSocket 통신 전송
-        if (!stompClientRef.current || !stompClientRef.current.connected) {
-            console.error('WebSocket not connected for random select');
-            return;
-        }
-
-        // 랜덤 선택 요청 데이터 구성
-        const randomSelectData = {
-            draftId: draftId
+            console.log('All participants completed:', allCompleted);
+            return allCompleted;
         };
 
-        console.log('Sending random player selection request:', randomSelectData);
+        // 4. 드래프트 완료 후 채팅방으로 리다이렉트 하는 함수
+        const handleDraftCompletion = async () => {
+            try {
+                const accessToken = localStorage.getItem("accessToken");
 
-        // WebSocket으로 랜덤 선택 요청 전송
-        stompClientRef.current.publish({
-            destination: '/app/draft/selectRandomPlayer',
-            body: JSON.stringify(randomSelectData)
-        });
-    };
+                const params = new URLSearchParams({draftId: draftId});
 
-    // 시간 만료 시 처리 함수 (수정됨)
-    const handleTimeExpired = () => {
-        const currentParticipant = participants[currentTurnIndex];
+                const response = await axiosInstance.get(
+                    `/api/chat-rooms/getChatroomId?${params.toString()}`);
 
-        // 현재 참가자가 실제 사용자(data-is-user가 true)인 경우에만 자동 선택
-        if (currentParticipant && !isBot(currentParticipant) && currentParticipant.userFlag === true && !isSelectingPlayer) {
-            performUserAutoSelect();
+                const chatRoomData = response.data;
+
+                // roomId를 이용해서 채팅방으로 리다이렉트
+                navigate(`/chatroom/${chatRoomData.roomId}`);
+
+            } catch (err) {
+                console.error("채팅방 정보를 가져오는데 실패했습니다:", err);
+                // 실패 시 기본 메시지 표시
+                alert('드래프트가 완료되었습니다.');
+            }
+        };
+
+        // 선택 가능한 선수 목록 가져오기
+        const getSelectablePlayers = () => {
+            return players.filter(player =>
+                isPlayerSelectable(player.status) &&
+                !selectedPlayerIds.includes(player.id)
+            );
+        };
+
+        // Bot 자동 선택 함수
+        const performBotAutoSelect = () => {
+            const currentParticipant = participants[currentTurnIndex];
+            if (!currentParticipant || !isBot(currentParticipant)) return;
+
+            console.log(
+                `Bot ${currentParticipant.participantId} is auto-selecting...`);
+
+            const selectablePlayers = getSelectablePlayers();
+            if (selectablePlayers.length === 0) {
+                console.log('No selectable players available for bot');
+                moveToNextTurn();
+                return;
+            }
+
+            // Bot은 포지션 제한을 고려하여 선택
+            let availablePlayer = null;
+            for (const player of selectablePlayers) {
+                const positionCheck = checkPositionLimit(player);
+                if (positionCheck.isValid) {
+                    availablePlayer = player;
+                    break;
+                }
+            }
+
+            if (!availablePlayer) {
+                console.log(
+                    'No available players within position limits for bot');
+                moveToNextTurn();
+                return;
+            }
+
+            console.log(`Bot selecting player: ${availablePlayer.name}`);
+            handlePlayerSelect(availablePlayer, true, true); // isAutoSelect, isBot
+        };
+
+        // 사용자 시간 만료 시 자동 선택 함수 (수정됨)
+        const performUserAutoSelect = () => {
+            const currentParticipant = participants[currentTurnIndex];
+            if (!currentParticipant || isBot(currentParticipant)) return;
+
+            // 현재 참가자가 실제 사용자(data-is-user가 true)가 아닌 경우 아무것도 하지 않음
+            if (currentParticipant.userFlag !== true) {
+                console.log(
+                    `Not a real user (userFlag: ${currentParticipant.userFlag}), waiting for WebSocket response...`);
+                return; // 대기 상태 유지, 다음 턴으로 이동하지 않음, 자동 선택하지 않음
+            }
+
+            console.log(
+                `User ${currentParticipant.participantId} time expired, sending random select request...`);
+
+            // 실제 사용자인 경우 랜덤 선택 WebSocket 통신 전송
+            if (!stompClientRef.current || !stompClientRef.current.connected) {
+                console.error('WebSocket not connected for random select');
+                return;
+            }
+
+            // 랜덤 선택 요청 데이터 구성
+            const randomSelectData = {
+                draftId: draftId
+            };
+
+            console.log('Sending random player selection request:',
+                randomSelectData);
+
+            // WebSocket으로 랜덤 선택 요청 전송
+            stompClientRef.current.publish({
+                destination: '/app/draft/selectRandomPlayer',
+                body: JSON.stringify(randomSelectData)
+            });
+        };
+
+        // 시간 만료 시 처리 함수 (수정됨)
+        const handleTimeExpired = () => {
+            const currentParticipant = participants[currentTurnIndex];
+
+            // 현재 참가자가 실제 사용자(data-is-user가 true)인 경우에만 자동 선택
+            if (currentParticipant && !isBot(currentParticipant)
+                && currentParticipant.userFlag === true && !isSelectingPlayer) {
+                performUserAutoSelect();
+                return;
+            }
+
+            // 그 외의 경우 (Bot이거나 data-is-user가 false인 다른 사용자) - 타이머 일시정지
+            console.log(
+                `Time expired for participant ${currentParticipant?.participantId}, pausing timer and waiting for WebSocket response...`);
+            setIsTimerPaused(true);
+            setDraftTime(0);
             return;
-        }
+        };
 
-        // 그 외의 경우 (Bot이거나 data-is-user가 false인 다른 사용자) - 타이머 일시정지
-        console.log(`Time expired for participant ${currentParticipant?.participantId}, pausing timer and waiting for WebSocket response...`);
-        setIsTimerPaused(true);
-        setDraftTime(0);
-        return;
-    };
+        // 2. 다음 턴으로 이동 (스네이크 드래프트 적용) (수정됨)
+        const moveToNextTurn = () => {
+            if (draftCompleted) return;
 
-    // 다음 턴으로 이동 (수정됨)
-    const moveToNextTurn = () => {
-        if (draftCompleted) return;
+            console.log('Moving to next turn...');
 
-        console.log('Moving to next turn...');
+            // 타이머 일시정지 해제
+            setIsTimerPaused(false);
 
-        // 타이머 일시정지 해제
-        setIsTimerPaused(false);
+            // 타이머들 정리
+            if (botAutoSelectTimer) {
+                clearTimeout(botAutoSelectTimer);
+                setBotAutoSelectTimer(null);
+            }
+            if (retryTimeoutRef.current) {
+                clearTimeout(retryTimeoutRef.current);
+                retryTimeoutRef.current = null;
+            }
+            if (turnTimer) {
+                clearInterval(turnTimer);
+                setTurnTimer(null);
+            }
 
-        // 타이머들 정리
-        if (botAutoSelectTimer) {
-            clearTimeout(botAutoSelectTimer);
-            setBotAutoSelectTimer(null);
-        }
-        if (retryTimeoutRef.current) {
-            clearTimeout(retryTimeoutRef.current);
-            retryTimeoutRef.current = null;
-        }
-        if (turnTimer) {
-            clearInterval(turnTimer);
-            setTurnTimer(null);
-        }
+            // 현재 상태의 participantPickCounts를 사용하여 총 선택 수 계산
+            setParticipantPickCounts(currentCounts => {
+                const totalSelections = Object.values(currentCounts).reduce(
+                    (sum, count) => sum + count, 0);
+                const nextTurnIndex = getSnakeDraftTurnIndex(totalSelections,
+                    participants.length);
 
-        setCurrentTurnIndex(current => {
-            const nextIndex = (current + 1) % participants.length;
-            setDraftTime(45); // 새로운 턴 시작시 45초로 리셋
-            console.log(`Turn moved from ${current} to ${nextIndex}`);
-            return nextIndex;
-        });
-    };
+                // 현재 라운드 계산 업데이트
+                const newRound = Math.floor(
+                    totalSelections / participants.length) + 1;
+                setCurrentRound(newRound);
+                setIsReverseRound(newRound % 2 === 0);
 
-    // 드래프트 턴 시스템 (수정됨)
-    useEffect(() => {
-        if (!draftStarted || participants.length === 0 || draftCompleted) return;
+                setCurrentTurnIndex(nextTurnIndex);
+                setDraftTime(60); // 새로운 턴 시작시 60초로 리셋
+                console.log(
+                    `Turn moved to ${nextTurnIndex} using snake draft (round: ${newRound}, totalSelections: ${totalSelections})`);
 
-        // 첫 번째 턴 설정
-        setCurrentTurnIndex(0);
-        setDraftTime(45);
+                return currentCounts; // 카운트는 변경하지 않음
+            });
+        };
 
-        const startTurnTimer = () => {
-            const timer = setInterval(() => {
+        // 드래프트 턴 시스템 (수정됨)
+        useEffect(() => {
+            if (!draftStarted || participants.length === 0
+                || draftCompleted) return;
+
+            // 첫 번째 턴 설정 - 드래프트 시작시에만 0으로 설정
+            setCurrentTurnIndex(0);
+            setDraftTime(60); // 1. 45초 -> 60초로 변경
+
+            console.log(`Initial turn set to: 0 (first participant)`);
+
+            const startTurnTimer = () => {
+                const timer = setInterval(() => {
+                    setDraftTime(prev => {
+                        // 타이머가 일시정지된 경우 카운트다운 멈춤
+                        if (isTimerPaused) {
+                            return prev;
+                        }
+
+                        if (prev <= 1) {
+                            // 시간 만료 처리
+                            handleTimeExpired();
+
+                            // 현재 참가자 확인
+                            const currentParticipant = participants[currentTurnIndex];
+
+                            // 실제 사용자(data-is-user가 true)인 경우에만 60초로 리셋
+                            if (currentParticipant &&
+                                !isBot(currentParticipant) &&
+                                currentParticipant.userFlag === true) {
+                                return 60; // 1. 45초 -> 60초로 변경
+                            }
+
+                            // Bot이거나 data-is-user가 false인 경우 0으로 유지
+                            return 0;
+                        }
+                        return prev - 1;
+                    });
+                }, 1000);
+                return timer;
+            };
+
+            const timer = startTurnTimer();
+            setTurnTimer(timer);
+
+            return () => {
+                if (timer) clearInterval(timer);
+            };
+        }, [draftStarted, participants.length, draftCompleted]);
+
+        // 턴 시작 시 Bot 체크 (수정됨 - Bot 자동 선택 제거)
+        useEffect(() => {
+            if (!draftStarted || draftCompleted || participants.length
+                === 0) return;
+
+            const currentParticipant = participants[currentTurnIndex];
+            if (!currentParticipant) return;
+
+            console.log(`Turn ${currentTurnIndex}: Participant`, {
+                id: currentParticipant.participantId,
+                userFlag: currentParticipant.userFlag,
+                userName: currentParticipant.userName,
+                isBot: isBot(currentParticipant)
+            });
+
+            // Bot 자동 선택 로직 제거 - Bot도 WebSocket 응답만 기다림
+
+            return () => {
+                if (botAutoSelectTimer) {
+                    clearTimeout(botAutoSelectTimer);
+                    setBotAutoSelectTimer(null);
+                }
+            };
+        }, [currentTurnIndex, draftStarted, draftCompleted, participants]);
+
+        // 턴 변경 시 타이머 리셋 (수정됨)
+        useEffect(() => {
+            if (!draftStarted || draftCompleted) return;
+
+            // 타이머 일시정지 해제
+            setIsTimerPaused(false);
+
+            if (turnTimer) {
+                clearInterval(turnTimer);
+            }
+
+            const newTimer = setInterval(() => {
                 setDraftTime(prev => {
                     // 타이머가 일시정지된 경우 카운트다운 멈춤
                     if (isTimerPaused) {
@@ -1023,17 +801,16 @@ export default function Draft() {
                     }
 
                     if (prev <= 1) {
-                        // 시간 만료 처리
                         handleTimeExpired();
 
                         // 현재 참가자 확인
                         const currentParticipant = participants[currentTurnIndex];
 
-                        // 실제 사용자(data-is-user가 true)인 경우에만 45초로 리셋
+                        // 실제 사용자(data-is-user가 true)인 경우에만 60초로 리셋
                         if (currentParticipant &&
                             !isBot(currentParticipant) &&
                             currentParticipant.userFlag === true) {
-                            return 45;
+                            return 60; // 1. 45초 -> 60초로 변경
                         }
 
                         // Bot이거나 data-is-user가 false인 경우 0으로 유지
@@ -1042,212 +819,348 @@ export default function Draft() {
                     return prev - 1;
                 });
             }, 1000);
-            return timer;
-        };
 
-        const timer = startTurnTimer();
-        setTurnTimer(timer);
+            setTurnTimer(newTimer);
 
-        return () => {
-            if (timer) clearInterval(timer);
-        };
-    }, [draftStarted, participants.length, draftCompleted]);
+            return () => {
+                if (newTimer) clearInterval(newTimer);
+            };
+        }, [currentTurnIndex, draftStarted, draftCompleted]);
 
-    // 턴 시작 시 Bot 체크 (수정됨 - Bot 자동 선택 제거)
-    useEffect(() => {
-        if (!draftStarted || draftCompleted || participants.length === 0) return;
+        // WebSocket 연결 설정 (일부 수정됨)
+        useEffect(() => {
+            const connectWebSocket = () => {
+                const token = localStorage.getItem("accessToken");
+                if (!token) {
+                    console.error("WebSocket 연결 실패: 토큰이 없음");
+                    return;
+                }
 
-        const currentParticipant = participants[currentTurnIndex];
-        if (!currentParticipant) return;
+                const socket = new SockJS(
+                    `${SOCKJS_ORIGIN}/ws-draft?token=Bearer ${encodeURIComponent(
+                        token)}`);
+                const stompClient = new Client({
+                    webSocketFactory: () => socket,
+                    debug: (str) => {
+                        console.log('STOMP Debug: ', str);
+                    },
+                    onConnect: (frame) => {
+                        console.log('Connected: ' + frame);
+                        console.log(`topic/draft is  ${draftId}`);
 
-        console.log(`Turn ${currentTurnIndex}: Participant`, {
-            id: currentParticipant.participantId,
-            userFlag: currentParticipant.userFlag,
-            userName: currentParticipant.userName,
-            isBot: isBot(currentParticipant)
-        });
+                        // 드래프트 토픽 구독
+                        stompClient.subscribe(`/topic/draft.${draftId}`,
+                            (message) => {
+                                const draftResponse = JSON.parse(message.body);
+                                console.log('Received draft message:',
+                                    draftResponse);
 
-        // Bot 자동 선택 로직 제거 - Bot도 WebSocket 응답만 기다림
+                                setIsSelectingPlayer(false); // 선수 선택 완료
 
-        return () => {
-            if (botAutoSelectTimer) {
-                clearTimeout(botAutoSelectTimer);
-                setBotAutoSelectTimer(null);
-            }
-        };
-    }, [currentTurnIndex, draftStarted, draftCompleted, participants]);
+                                // alreadySelected에 따른 처리
+                                if (draftResponse.alreadySelected) {
+                                    console.log(
+                                        'Player already selected, retrying...');
 
-    // WebSocket 연결 설정 (드래프트용 - 기존 로직 유지)
-    useEffect(() => {
-        const connectWebSocket = () => {
-            const token = localStorage.getItem("accessToken");
-            if (!token) {
-                console.error("WebSocket 연결 실패: 토큰이 없음");
+                                    const currentParticipant = participants[currentTurnIndex];
+
+                                    // Bot인 경우 다시 시도 (Bot 자동 선택 제거)
+                                    if (currentParticipant && isBot(
+                                        currentParticipant)) {
+                                        console.log(
+                                            'Bot retrying selection - but auto selection removed, waiting for WebSocket...');
+                                        // Bot 자동 선택 로직 제거 - WebSocket 응답만 기다림
+                                    } else {
+                                        // 실제 사용자인 경우 알림만 표시하고 타이머 재시작
+                                        alert(
+                                            '이미 선택 된 선수입니다. 다시 선택해 주시기 바랍니다.');
+
+                                        // data-is-user가 false인 다른 사용자의 경우 타이머를 60초로 재시작
+                                        if (currentParticipant && !isBot(
+                                                currentParticipant)
+                                            && currentParticipant.userFlag
+                                            !== true) {
+                                            setDraftTime(60); // 1. 45초 -> 60초로 변경
+                                        }
+                                    }
+                                } else {
+                                    console.log('Player selection successful');
+
+                                    // 3. 선수 선택 성공 알림 메시지 표시
+                                    const playerName = draftResponse.playerKrName
+                                    && draftResponse.playerKrName.trim() !== ''
+                                        ? draftResponse.playerKrName
+                                        : draftResponse.playerWebName;
+                                    const userName = draftResponse.userName
+                                        || '참가자';
+
+                                    setPlayerSelectMessage(
+                                        `${userName}님께서 ${playerName}를 선택하셨습니다.`);
+                                    setShowPlayerSelectMessage(true);
+
+                                    // 1초 후 메시지 숨기기
+                                    setTimeout(() => {
+                                        setShowPlayerSelectMessage(false);
+                                    }, 1000);
+
+                                    // 성공적으로 선택된 경우 선수 ID 추가
+                                    if (draftResponse.playerId) {
+                                        setSelectedPlayerIds(prev => [...prev,
+                                            draftResponse.playerId]);
+
+                                        // 드래프트된 선수 리스트에도 추가
+                                        setDraftedPlayers(
+                                            prev => [...prev, draftResponse]);
+                                    }
+
+                                    // 현재 참가자의 선택 카운트 증가
+                                    const currentParticipant = participants[currentTurnIndex];
+                                    if (currentParticipant) {
+                                        setParticipantPickCounts(prev => {
+                                            const updatedCounts = {
+                                                ...prev,
+                                                [currentParticipant.participantId]: (prev[currentParticipant.participantId]
+                                                    || 0) + 1
+                                            };
+
+                                            console.log('Updated pick counts:',
+                                                updatedCounts);
+
+                                            // 드래프트 완료 체크
+                                            const isCompleted = checkDraftCompletion(
+                                                updatedCounts);
+                                            if (isCompleted) {
+                                                console.log(
+                                                    'Draft completed! Setting draftCompleted to true');
+                                                setTimeout(() => {
+                                                    setDraftCompleted(true);
+                                                    if (turnTimer) {
+                                                        clearInterval(
+                                                            turnTimer);
+                                                        setTurnTimer(null);
+                                                    }
+                                                    // 4. 드래프트 완료 후 채팅방으로 리다이렉트
+                                                    handleDraftCompletion();
+                                                }, 1000);
+                                                return updatedCounts;
+                                            }
+
+                                            return updatedCounts;
+                                        });
+
+                                        // 사용자인 경우 myPlayerCount 증가
+                                        if (!isBot(currentParticipant)) {
+                                            setMyPlayerCount(prev => prev + 1);
+                                        }
+                                    }
+
+                                    // 드래프트가 완료되지 않은 경우에만 다음 턴으로 이동
+                                    setTimeout(() => {
+                                        setParticipantPickCounts(
+                                            currentCounts => {
+                                                const isCompleted = checkDraftCompletion(
+                                                    currentCounts);
+                                                if (!isCompleted) {
+                                                    moveToNextTurn();
+                                                }
+                                                return currentCounts;
+                                            });
+                                    }, 1500);
+                                }
+                            });
+                    },
+                    onStompError: (frame) => {
+                        console.error('Broker reported error: '
+                            + frame.headers['message']);
+                        console.error('Additional details: ' + frame.body);
+                        setIsSelectingPlayer(false);
+                    },
+                    onWebSocketError: (error) => {
+                        console.error('WebSocket error: ', error);
+                        setIsSelectingPlayer(false);
+                    },
+                    onDisconnect: () => {
+                        console.log('Disconnected');
+                        setIsSelectingPlayer(false);
+                    }
+                });
+
+                stompClient.activate();
+                stompClientRef.current = stompClient;
+            };
+
+            connectWebSocket();
+
+            // 컴포넌트 언마운트 시 연결 해제
+            return () => {
+                if (stompClientRef.current) {
+                    stompClientRef.current.deactivate();
+                }
+            };
+        }, [draftId, participants, currentTurnIndex, turnTimer]);
+
+        // ElementType 데이터 fetch
+        useEffect(() => {
+            const fetchElementTypes = async () => {
+                try {
+                    const response = await axiosInstance.get(
+                        '/api/elementType/all');
+                    const elementTypeData = response.data;
+                    setElementTypes(elementTypeData);
+                } catch (err) {
+                    console.error('포지션 데이터를 가져오는데 실패했습니다:', err);
+                }
+            };
+
+            fetchElementTypes();
+        }, []);
+
+        // 선수 데이터 fetch
+        useEffect(() => {
+            const fetchPlayers = async () => {
+                try {
+                    setPlayersLoading(true);
+                    const response = await axiosInstance.get(
+                        '/api/playerCache');
+                    const playerData = response.data;
+
+                    // PlayerDto 데이터를 화면에 표시할 형태로 변환
+                    const transformedPlayers = playerData.map(player => ({
+                        // 화면 표시용 데이터
+                        name: player.krName && player.krName.trim() !== ''
+                            ? player.krName : player.webName,
+                        team: player.teamKrName && player.teamKrName.trim()
+                        !== '' ? player.teamKrName : player.teamName,
+                        position: getPositionCode(player.elementTypePluralName),
+                        pic: player.pic,
+
+                        // hidden 데이터 (화면에는 안 보이지만 저장)
+                        id: player.id,
+                        webName: player.webName,
+                        krName: player.krName,
+                        status: player.status,
+                        teamName: player.teamName,
+                        teamKrName: player.teamKrName,
+                        elementTypeId: player.elementTypeId,
+                        elementTypePluralName: player.elementTypePluralName,
+                        elementTypeKrName: player.elementTypeKrName
+                    }));
+
+                    setPlayers(transformedPlayers);
+                    setError(null);
+                } catch (err) {
+                    console.error('선수 데이터를 가져오는데 실패했습니다:', err);
+                    setError(err.message);
+                } finally {
+                    setPlayersLoading(false);
+                }
+            };
+
+            fetchPlayers();
+        }, []);
+
+        // 선수 선택 핸들러 (수정된 부분)
+        const handlePlayerSelect = (player, isAutoSelect = false,
+            isBotSelect = false) => {
+            // 드래프트가 완료된 경우
+            if (draftCompleted) {
                 return;
             }
 
-            // 드래프트용 WebSocket URL (기존 로직 유지)
-            const socket = new SockJS(`${import.meta.env.VITE_API_BASE_URL}/ws-draft?token=Bearer ${encodeURIComponent(token)}`);
-            const stompClient = new Client({
-                webSocketFactory: () => socket,
-                debug: (str) => {
-                    console.log('STOMP Debug: ', str);
-                },
-                onConnect: (frame) => {
-                    console.log('Connected: ' + frame);
-                    console.log(`topic/draft is  ${draftId}` );
+            const currentParticipant = participants[currentTurnIndex];
+            if (!currentParticipant) return;
 
-                    // 드래프트 토픽 구독
-                    stompClient.subscribe(`/topic/draft.${draftId}`, (message) => {
-                        const draftResponse = JSON.parse(message.body);
-                        console.log('Received draft message:', draftResponse);
-
-                        setIsSelectingPlayer(false); // 선수 선택 완료
-
-                        // alreadySelected에 따른 처리
-                        if (draftResponse.alreadySelected) {
-                            console.log('Player already selected, retrying...');
-
-                            const currentParticipant = participants[currentTurnIndex];
-
-                            // Bot인 경우 다시 시도 (Bot 자동 선택 제거)
-                            if (currentParticipant && isBot(currentParticipant)) {
-                                console.log('Bot retrying selection - but auto selection removed, waiting for WebSocket...');
-                                // Bot 자동 선택 로직 제거 - WebSocket 응답만 기다림
-                            } else {
-                                // 실제 사용자인 경우 알림만 표시하고 타이머 재시작
-                                alert('이미 선택 된 선수입니다. 다시 선택해 주시기 바랍니다.');
-
-                                // data-is-user가 false인 다른 사용자의 경우 타이머를 45초로 재시작
-                                if (currentParticipant && !isBot(currentParticipant) && currentParticipant.userFlag !== true) {
-                                    setDraftTime(45);
-                                }
-                            }
-                        } else {
-                            console.log('Player selection successful');
-
-                            // 성공적으로 선택된 경우 선수 ID 추가
-                            if (draftResponse.playerId) {
-                                setSelectedPlayerIds(prev => [...prev, draftResponse.playerId]);
-
-                                // 드래프트된 선수 리스트에도 추가
-                                setDraftedPlayers(prev => [...prev, draftResponse]);
-                            }
-
-                            // 현재 참가자의 선택 카운트 증가
-                            const currentParticipant = participants[currentTurnIndex];
-                            if (currentParticipant) {
-                                setParticipantPickCounts(prev => {
-                                    const updatedCounts = {
-                                        ...prev,
-                                        [currentParticipant.participantId]: (prev[currentParticipant.participantId] || 0) + 1
-                                    };
-
-                                    console.log('Updated pick counts:', updatedCounts);
-
-                                    // 드래프트 완료 체크
-                                    const isCompleted = checkDraftCompletion(updatedCounts);
-                                    if (isCompleted) {
-                                        console.log('Draft completed! Setting draftCompleted to true');
-                                        setTimeout(() => {
-                                            setDraftCompleted(true);
-                                            if (turnTimer) {
-                                                clearInterval(turnTimer);
-                                                setTurnTimer(null);
-                                            }
-                                        }, 1000);
-                                        return updatedCounts;
-                                    }
-
-                                    return updatedCounts;
-                                });
-
-                                // 사용자인 경우 myPlayerCount 증가
-                                if (!isBot(currentParticipant)) {
-                                    setMyPlayerCount(prev => prev + 1);
-                                }
-                            }
-
-                            // 드래프트가 완료되지 않은 경우에만 다음 턴으로 이동
-                            setTimeout(() => {
-                                setParticipantPickCounts(currentCounts => {
-                                    const isCompleted = checkDraftCompletion(currentCounts);
-                                    if (!isCompleted) {
-                                        moveToNextTurn();
-                                    }
-                                    return currentCounts;
-                                });
-                            }, 1500);
-                        }
-                    });
-                },
-                onStompError: (frame) => {
-                    console.error('Broker reported error: ' + frame.headers['message']);
-                    console.error('Additional details: ' + frame.body);
-                    setIsSelectingPlayer(false);
-                },
-                onWebSocketError: (error) => {
-                    console.error('WebSocket error: ', error);
-                    setIsSelectingPlayer(false);
-                },
-                onDisconnect: () => {
-                    console.log('Disconnected');
-                    setIsSelectingPlayer(false);
+            // 자동 선택이나 Bot 선택이 아닌 경우 사용자의 차례인지 확인
+            if (!isAutoSelect && !isBotSelect) {
+                if (!isMyTurn()) {
+                    setShowWarningMessage(true);
+                    setTimeout(() => {
+                        setShowWarningMessage(false);
+                    }, 3000);
+                    return;
                 }
+            }
+
+            // 현재 참가자가 Bot이 아닌데 사용자가 선택하려 하는 경우 (기존 로직)
+            if (isBot(currentParticipant) && !isAutoSelect && !isBotSelect) {
+                setShowWarningMessage(true);
+                setTimeout(() => {
+                    setShowWarningMessage(false);
+                }, 3000);
+                return;
+            }
+
+            // 이미 선수 선택 중인 경우
+            if (isSelectingPlayer) {
+                return;
+            }
+
+            // 포지션 제한 체크 (Bot이 아닌 사용자나 수동 선택인 경우에만)
+            if (!isBotSelect && !isAutoSelect) {
+                const positionCheck = checkPositionLimit(player);
+                if (!positionCheck.isValid) {
+                    alert(positionCheck.message);
+                    return;
+                }
+            }
+
+            if (!stompClientRef.current || !stompClientRef.current.connected) {
+                if (!isBotSelect) {
+                    alert('서버 연결이 끊어졌습니다. 페이지를 새로고침해 주세요.');
+                }
+                return;
+            }
+
+            setIsSelectingPlayer(true);
+
+            // 선수 선택 데이터 구성
+            const selectPlayerData = {
+                draftId: draftId,
+                playerId: player.id,
+                playerWebName: player.webName,
+                playerKrName: player.krName,
+                playerPic: player.pic,
+                teamName: player.teamName,
+                teamKrName: player.teamKrName,
+                elementTypeId: player.elementTypeId,
+                elementTypePluralName: player.elementTypePluralName,
+                elementTypeKrName: player.elementTypeKrName
+            };
+
+            console.log('Sending player selection:', selectPlayerData);
+
+            // WebSocket으로 선수 선택 요청 전송
+            stompClientRef.current.publish({
+                destination: '/app/draft/selectPlayer',
+                body: JSON.stringify(selectPlayerData)
             });
-
-            stompClient.activate();
-            stompClientRef.current = stompClient;
         };
 
-        connectWebSocket();
-
-        // 컴포넌트 언마운트 시 연결 해제
-        return () => {
-            if (stompClientRef.current) {
-                stompClientRef.current.deactivate();
-            }
-        };
-    }, [draftId, participants, currentTurnIndex, turnTimer]);
-
-    // ElementType 데이터 fetch
-    useEffect(() => {
-        const fetchElementTypes = async () => {
-            try {
-                const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/api/elementType/all`);
-
-                if (!response.ok) {
-                    throw new Error(`HTTP error! status: ${response.status}`);
-                }
-
-                const elementTypeData = await response.json();
-                setElementTypes(elementTypeData);
-            } catch (err) {
-                console.error('포지션 데이터를 가져오는데 실패했습니다:', err);
-            }
-        };
-
-        fetchElementTypes();
-    }, []);
-
-    // 선수 데이터 fetch
-    useEffect(() => {
-        const fetchPlayers = async () => {
+        // 선수 검색 함수
+        const handlePlayerSearch = async () => {
             try {
                 setPlayersLoading(true);
-                const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/api/playerCache`);
+                const params = new URLSearchParams();
 
-                if (!response.ok) {
-                    throw new Error(`HTTP error! status: ${response.status}`);
+                if (searchParams.keyword.trim() !== '') {
+                    params.append('keyword', searchParams.keyword.trim());
                 }
 
-                const playerData = await response.json();
+                if (searchParams.elementTypeId !== '') {
+                    params.append('elementTypeId', searchParams.elementTypeId);
+                }
 
-                // PlayerDto 데이터를 화면에 표시할 형태로 변환
-                const transformedPlayers = playerData.map(player => ({
+                const response = await axiosInstance.get(
+                    `/api/playerEs/search?${params.toString()}`);
+                const searchResults = response.data;
+
+                // PlayerEsDocument 데이터를 화면에 표시할 형태로 변환
+                const transformedPlayers = searchResults.map(player => ({
                     // 화면 표시용 데이터
-                    name: player.krName && player.krName.trim() !== '' ? player.krName : player.webName,
-                    team: player.teamKrName && player.teamKrName.trim() !== '' ? player.teamKrName : player.teamName,
+                    name: player.krName && player.krName.trim() !== ''
+                        ? player.krName : player.webName,
+                    team: player.teamKrName && player.teamKrName.trim() !== ''
+                        ? player.teamKrName : player.teamName,
                     position: getPositionCode(player.elementTypePluralName),
                     pic: player.pic,
 
@@ -1266,689 +1179,998 @@ export default function Draft() {
                 setPlayers(transformedPlayers);
                 setError(null);
             } catch (err) {
-                console.error('선수 데이터를 가져오는데 실패했습니다:', err);
+                console.error('검색에 실패했습니다:', err);
                 setError(err.message);
             } finally {
                 setPlayersLoading(false);
             }
         };
 
-        fetchPlayers();
-    }, []);
-
-    // 선수 선택 핸들러 (수정된 부분)
-    const handlePlayerSelect = (player, isAutoSelect = false, isBotSelect = false) => {
-        // 드래프트가 완료된 경우
-        if (draftCompleted) {
-            return;
-        }
-
-        const currentParticipant = participants[currentTurnIndex];
-        if (!currentParticipant) return;
-
-        // 자동 선택이나 Bot 선택이 아닌 경우 사용자의 차례인지 확인
-        if (!isAutoSelect && !isBotSelect) {
-            if (!isMyTurn()) {
-                setShowWarningMessage(true);
-                setTimeout(() => {
-                    setShowWarningMessage(false);
-                }, 3000);
-                return;
-            }
-        }
-
-        // 현재 참가자가 Bot이 아닌데 사용자가 선택하려 하는 경우 (기존 로직)
-        if (isBot(currentParticipant) && !isAutoSelect && !isBotSelect) {
-            setShowWarningMessage(true);
-            setTimeout(() => {
-                setShowWarningMessage(false);
-            }, 3000);
-            return;
-        }
-
-        // 이미 선수 선택 중인 경우
-        if (isSelectingPlayer) {
-            return;
-        }
-
-        // 포지션 제한 체크 (Bot이 아닌 사용자나 수동 선택인 경우에만)
-        if (!isBotSelect && !isAutoSelect) {
-            const positionCheck = checkPositionLimit(player);
-            if (!positionCheck.isValid) {
-                alert(positionCheck.message);
-                return;
-            }
-        }
-
-        if (!stompClientRef.current || !stompClientRef.current.connected) {
-            if (!isBotSelect) {
-                alert('서버 연결이 끊어졌습니다. 페이지를 새로고침해 주세요.');
-            }
-            return;
-        }
-
-        setIsSelectingPlayer(true);
-
-        // 선수 선택 데이터 구성
-        const selectPlayerData = {
-            draftId: draftId,
-            playerId: player.id,
-            playerWebName: player.webName,
-            playerKrName: player.krName,
-            playerPic: player.pic,
-            teamName: player.teamName,
-            teamKrName: player.teamKrName,
-            elementTypeId: player.elementTypeId,
-            elementTypePluralName: player.elementTypePluralName,
-            elementTypeKrName: player.elementTypeKrName
-        };
-
-        console.log('Sending player selection:', selectPlayerData);
-
-        // WebSocket으로 선수 선택 요청 전송
-        stompClientRef.current.publish({
-            destination: '/app/draft/selectPlayer',
-            body: JSON.stringify(selectPlayerData)
-        });
-    };
-
-    // 검색 함수
-    const handleSearch = async () => {
-        try {
-            setLoading(true);
-            const params = new URLSearchParams();
-
-            if (searchParams.keyword.trim() !== '') {
-                params.append('keyword', searchParams.keyword.trim());
-            }
-
-            if (searchParams.elementTypeId !== '') {
-                params.append('elementTypeId', searchParams.elementTypeId);
-            }
-
-            const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/api/playerEs/search?${params.toString()}`);
-
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-            }
-
-            const searchResults = await response.json();
-
-            // PlayerEsDocument 데이터를 화면에 표시할 형태로 변환
-            const transformedPlayers = searchResults.map(player => ({
-                // 화면 표시용 데이터
-                name: player.krName && player.krName.trim() !== '' ? player.krName : player.webName,
-                team: player.teamKrName && player.teamKrName.trim() !== '' ? player.teamKrName : player.teamName,
-                position: getPositionCode(player.elementTypePluralName),
-                pic: player.pic,
-
-                // hidden 데이터 (화면에는 안 보이지만 저장)
-                id: player.id,
-                webName: player.webName,
-                krName: player.krName,
-                status: player.status,
-                teamName: player.teamName,
-                teamKrName: player.teamKrName,
-                elementTypeId: player.elementTypeId,
-                elementTypePluralName: player.elementTypePluralName,
-                elementTypeKrName: player.elementTypeKrName
+        // 검색 입력값 변경 핸들러
+        const handleSearchInputChange = (name, value) => {
+            setSearchParams(prev => ({
+                ...prev,
+                [name]: value
             }));
-
-            setPlayers(transformedPlayers);
-            setError(null);
-        } catch (err) {
-            console.error('검색에 실패했습니다:', err);
-            setError(err.message);
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    // 검색 입력값 변경 핸들러
-    const handleSearchInputChange = (name, value) => {
-        setSearchParams(prev => ({
-            ...prev,
-            [name]: value
-        }));
-    };
-
-    // 검색 엔터 키 처리
-    const handleSearchKeyPress = (e) => {
-        if (e.key === 'Enter') {
-            handleSearch();
-        }
-    };
-
-    // status에 따른 비활성화 사유 반환
-    const getStatusReason = (status) => {
-        switch (status) {
-            case 'd':
-                return '출전 불투명';
-            case 'i':
-                return '부상';
-            case 's':
-                return '징계';
-            case 'u':
-                return '사용불(임대 등)';
-            case 'n':
-                return '자격 없음(미등록 선수)';
-            default:
-                return '';
-        }
-    };
-
-    // 선수 선택 가능 여부 확인
-    const isPlayerSelectable = (status) => {
-        return status === 'a';
-    };
-
-    const getPositionCode = (elementTypePluralName) => {
-        switch (elementTypePluralName) {
-            case 'Forwards':
-                return 'FW';
-            case 'Midfielders':
-                return 'MF';
-            case 'Defenders':
-                return 'DF';
-            case 'Goalkeepers':
-                return 'GK';
-            default:
-                return '';
-        }
-    };
-
-    const formatDraftTime = (seconds) =>
-        `${String(Math.floor(seconds / 60)).padStart(2, '0')}:${String(seconds % 60).padStart(2, '0')}`;
-
-    // 메시지 전송
-    const handleSendMessage = () => {
-        if (isComposing) return;
-        if (!message.trim()) return;
-
-        if (!chatStompClientRef.current?.connected) {
-            alert('채팅 서버에 연결되지 않았습니다. 잠시 후 다시 시도해주세요.');
-            return;
-        }
-
-        const messageData = {
-            roomId: chatRoomId,               // ← 통일
-            content: message.trim()
         };
 
-        const token = getAuthToken();
-        try {
-            chatStompClientRef.current.publish({
-                destination: `/app/chat/${chatRoomId}/send`,   // ← 통일
-                body: JSON.stringify(messageData)
-            });
-            setMessage('');
-        } catch (error) {
-            console.error('❌ 메시지 전송 실패:', error);
-            alert('메시지 전송에 실패했습니다.');
-        }
-    };
-
-    // 드래프트 나가기
-    const handleExit = () => {
-        if (window.confirm('정말로 드래프트에서 나가시겠습니까?')) {
-            // WebSocket 연결 해제
-            if (stompClientRef.current) {
-                stompClientRef.current.deactivate();
+        // 검색 엔터 키 처리
+        const handleSearchKeyPress = (e) => {
+            if (e.key === 'Enter') {
+                handlePlayerSearch();
             }
-            if (chatStompClientRef.current) {
-                chatStompClientRef.current.deactivate();
+        };
+
+        // status에 따른 비활성화 사유 반환
+        const getStatusReason = (status) => {
+            switch (status) {
+                case 'd':
+                    return '출전 불투명';
+                case 'i':
+                    return '부상';
+                case 's':
+                    return '징계';
+                case 'u':
+                    return '사용불(임대 등)';
+                case 'n':
+                    return '자격 없음(미등록 선수)';
+                default:
+                    return '';
             }
-            // 타이머들 정리
-            if (turnTimer) {
-                clearInterval(turnTimer);
+        };
+
+        // 선수 선택 가능 여부 확인
+        const isPlayerSelectable = (status) => {
+            return status === 'a';
+        };
+
+        const getPositionCode = (elementTypePluralName) => {
+            switch (elementTypePluralName) {
+                case 'Forwards':
+                    return 'FW';
+                case 'Midfielders':
+                    return 'MF';
+                case 'Defenders':
+                    return 'DF';
+                case 'Goalkeepers':
+                    return 'GK';
+                default:
+                    return '';
             }
-            if (autoSelectTimeoutRef.current) {
-                clearTimeout(autoSelectTimeoutRef.current);
+        };
+
+        const formatTimerDisplay = (seconds) =>
+            `${String(Math.floor(seconds / 60)).padStart(2, '0')}:${String(
+                seconds % 60).padStart(2, '0')}`;
+
+        // 채팅 검색 함수
+        const searchChatMessages = async (query) => {
+            if (!query.trim() || !chatRoomId) {
+                setSearchResults([]);
+                setShowSearchResults(false);
+                return;
             }
-            if (botAutoSelectTimer) {
-                clearTimeout(botAutoSelectTimer);
+
+            setIsSearching(true);
+            try {
+                const response = await axiosInstance.get(
+                    `/api/chat-rooms/${chatRoomId}/search`, {
+                        params: {
+                            q: query.trim(),
+                            limit: 20
+                        }
+                    });
+
+                const {items} = response.data;
+                setSearchResults(items.map(formatMessage));
+                setShowSearchResults(true);
+            } catch (error) {
+                console.error('채팅 검색 실패:', error);
+                setSearchResults([]);
+                setShowSearchResults(false);
+            } finally {
+                setIsSearching(false);
             }
-            if (retryTimeoutRef.current) {
-                clearTimeout(retryTimeoutRef.current);
+        };
+
+        // 채팅 검색 실행
+        const handleChatSearch = () => {
+            searchChatMessages(searchQuery);
+        };
+
+        // 검색 초기화
+        const clearSearch = () => {
+            setSearchQuery('');
+            setSearchResults([]);
+            setShowSearchResults(false);
+        };
+
+        // 채팅 히스토리 초기 로드 (최신 메시지부터)
+        const loadInitialHistory = async () => {
+            if (loading || !chatRoomId) {
+                return;
             }
-            alert('메인 페이지로 돌아갑니다.');
-            navigate('/');
-        }
-    };
+            setLoading(true);
 
-    useEffect(() => {
-        if (chatBoxRef.current) {
-            chatBoxRef.current.scrollTop = chatBoxRef.current.scrollHeight;
-        }
-    }, [chatList]);
+            try {
+                const response = await axiosInstance.get(
+                    `/api/chat-rooms/${chatRoomId}/messages`, {
+                        params: {limit: 30}
+                    });
 
-    // 현재 턴인 참가자 정보 가져오기
-    const getCurrentTurnParticipant = () => {
-        if (!draftStarted || participants.length === 0 || draftCompleted) return null;
-        return participants[currentTurnIndex];
-    };
+                const {
+                    items,
+                    nextCursor: cursor,
+                    hasMore: more
+                } = response.data;
 
-    const currentTurnParticipant = getCurrentTurnParticipant();
-    const selectedParticipantDraftedPlayers = getSelectedParticipantDraftedPlayers();
+                setChatList(items.map(formatMessage));
+                setNextCursor(cursor);
+                setHasMore(more);
+                setIsInitialLoad(false);
 
-    return (
-        <>
-            {/* Hidden draftId value */}
-            <div style={{ display: 'none' }} data-draft-id={draftId}></div>
+                // 초기 로드 완료 후 즉시 맨 아래로 스크롤 (애니메이션 없이)
+                requestAnimationFrame(() => {
+                    if (chatBoxRef.current) {
+                        chatBoxRef.current.scrollTop = chatBoxRef.current.scrollHeight;
+                    }
+                });
 
-            {/* Hidden drafted players data */}
-            <div style={{ display: 'none' }} id="drafted-players-data">
-                {draftedPlayers.map((player, idx) => (
-                    <div key={idx} data-drafted-player={JSON.stringify(player)}></div>
-                ))}
-            </div>
+            } catch (error) {
+                console.error('채팅 히스토리 초기 로드 실패:', error);
+            } finally {
+                setLoading(false);
+            }
+        };
 
-            {/* 드래프트 시작 카운트다운 오버레이 */}
-            {showCountdown && (
-                <div className="countdown-overlay">
-                    <div className="countdown-content">
-                        <h2>{countdown}초 후에 드래프트가 시작됩니다.</h2>
-                    </div>
+        // 이전 메시지 로드 (무한스크롤)
+        const loadMoreMessages = async () => {
+            if (loading || !nextCursor || !hasMore || !chatRoomId) {
+                return;
+            }
+            setLoading(true);
+
+            try {
+                const response = await axiosInstance.get(
+                    `/api/chat-rooms/${chatRoomId}/messages/before`, {
+                        params: {
+                            cursor: nextCursor,
+                            limit: 30
+                        }
+                    });
+
+                const {
+                    items,
+                    nextCursor: cursor,
+                    hasMore: more
+                } = response.data;
+
+                const currentScrollHeight = chatBoxRef.current?.scrollHeight
+                    || 0;
+
+                setChatList(prev => [...items.map(formatMessage), ...prev]);
+                setNextCursor(cursor);
+                setHasMore(more);
+
+                setTimeout(() => {
+                    if (chatBoxRef.current) {
+                        const newScrollHeight = chatBoxRef.current.scrollHeight;
+                        const heightDiff = newScrollHeight
+                            - currentScrollHeight;
+                        chatBoxRef.current.scrollTop = chatBoxRef.current.scrollTop
+                            + heightDiff;
+                    }
+                }, 50);
+
+            } catch (error) {
+                console.error('이전 메시지 로드 실패:', error);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        // 채팅 WebSocket 연결
+        const connectChatWebSocket = useCallback(() => {
+            if (chatStompClientRef.current?.connected || !chatRoomId) {
+                return;
+            }
+
+            const token = getAuthToken();
+            if (!token) {
+                console.error('인증 토큰이 없습니다.');
+                setIsConnected(false);
+                return;
+            }
+
+            try {
+                const socket = new SockJS(`${SOCKJS_ORIGIN}/ws`);
+                const chatStompClient = new Client({
+                    webSocketFactory: () => socket,
+                    connectHeaders: {
+                        'Authorization': `Bearer ${token}`
+                    },
+                    debug: (str) => {
+                        console.log('채팅 STOMP:', str);
+                    },
+                    onConnect: (frame) => {
+                        console.log('채팅 WebSocket 연결 성공:', frame);
+                        setIsConnected(true);
+
+                        // 채팅방 구독
+                        const subscription = chatStompClient.subscribe(
+                            `/topic/chat/${chatRoomId}`, (message) => {
+                                const newMessage = JSON.parse(message.body);
+
+                                // 사용자 이름 결정
+                                let userName = '시스템';
+                                if (newMessage.type === 'ALERT'
+                                    || newMessage.type === 'SYSTEM') {
+                                    userName = '⚽ 알림';
+                                } else if (newMessage.userId) {
+                                    if (currentUser && newMessage.userId
+                                        === currentUser.id) {
+                                        userName = currentUser.email;
+                                    } else {
+                                        userName = newMessage.userEmail
+                                            || '알 수 없는 사용자';
+                                    }
+                                }
+
+                                const formattedMessage = {
+                                    id: newMessage.id || Date.now().toString(),
+                                    user: userName,
+                                    text: newMessage.content,
+                                    time: formatTime(
+                                        newMessage.createdAt || new Date()),
+                                    type: newMessage.type,
+                                    userId: newMessage.userId
+                                };
+
+                                setChatList(prev => {
+                                    const newList = [...prev, formattedMessage];
+
+                                    // 새 메시지 추가 후 즉시 스크롤을 맨 아래로
+                                    requestAnimationFrame(() => {
+                                        if (chatBoxRef.current) {
+                                            const scrollElement = chatBoxRef.current;
+                                            scrollElement.scrollTop = scrollElement.scrollHeight;
+                                        }
+                                    });
+
+                                    return newList;
+                                });
+                            }, {
+                                'Authorization': `Bearer ${token}`
+                            });
+
+                        console.log('채팅 구독 완료:', subscription);
+                    },
+                    onDisconnect: (frame) => {
+                        console.log('채팅 WebSocket 연결 해제:', frame);
+                        setIsConnected(false);
+                    },
+                    onStompError: (frame) => {
+                        console.error('채팅 STOMP 오류:', frame);
+                        setIsConnected(false);
+
+                        setTimeout(() => {
+                            if (!chatStompClientRef.current?.connected) {
+                                console.log('채팅 WebSocket 재연결 시도...');
+                                connectChatWebSocket();
+                            }
+                        }, 3000);
+                    },
+                    onWebSocketError: (error) => {
+                        console.error('채팅 WebSocket 오류:', error);
+                    },
+                    reconnectDelay: 5000,
+                    heartbeatIncoming: 4000,
+                    heartbeatOutgoing: 4000
+                });
+
+                chatStompClient.activate();
+                chatStompClientRef.current = chatStompClient;
+                console.log('채팅 STOMP 클라이언트 활성화됨');
+            } catch (error) {
+                console.error('채팅 WebSocket 연결 실패:', error);
+                setIsConnected(false);
+            }
+        }, [chatRoomId, currentUser]);
+
+        // 메시지 전송
+        const handleSendMessage = () => {
+            if (isComposing) {
+                return;
+            }
+            if (!message.trim()) {
+                return;
+            }
+
+            if (!chatStompClientRef.current?.connected) {
+                alert('채팅 서버에 연결되지 않았습니다. 잠시 후 다시 시도해주세요.');
+                return;
+            }
+
+            const messageData = {
+                roomId: chatRoomId,
+                content: message.trim()
+            };
+
+            try {
+                chatStompClientRef.current.publish({
+                    destination: `/app/chat/${chatRoomId}/send`,
+                    body: JSON.stringify(messageData)
+                });
+                setMessage('');
+            } catch (error) {
+                console.error('메시지 전송 실패:', error);
+                alert('메시지 전송에 실패했습니다.');
+            }
+        };
+
+        // 채팅 전송 (기존 이벤트 핸들러 수정)
+        const handleSend = () => {
+            handleSendMessage();
+        };
+
+        // 채팅 엔터 (기존 이벤트 핸들러 수정)
+        const handleKeyPress = (e) => {
+            if (e.key === 'Enter') handleSend();
+        };
+
+        // 무한스크롤 로드 디바운스
+        const debouncedLoadMore = useCallback(
+            debounce(() => {
+                if (hasMore && !loading && !isInitialLoad) {
+                    loadMoreMessages();
+                }
+            }, 300),
+            [hasMore, loading, nextCursor, isInitialLoad, chatRoomId]
+        );
+
+        // 드래프트 나가기
+        const handleExit = () => {
+            if (window.confirm('정말로 드래프트에서 나가시겠습니까?')) {
+                // WebSocket 연결 해제
+                if (stompClientRef.current) {
+                    stompClientRef.current.deactivate();
+                }
+                if (chatStompClientRef.current) {
+                    chatStompClientRef.current.deactivate();
+                }
+                // 타이머들 정리
+                if (turnTimer) {
+                    clearInterval(turnTimer);
+                }
+                if (autoSelectTimeoutRef.current) {
+                    clearTimeout(autoSelectTimeoutRef.current);
+                }
+                if (botAutoSelectTimer) {
+                    clearTimeout(botAutoSelectTimer);
+                }
+                if (retryTimeoutRef.current) {
+                    clearTimeout(retryTimeoutRef.current);
+                }
+                alert('메인 페이지로 돌아갑니다.');
+                navigate('/');
+            }
+        };
+
+        // 무한스크롤 트리거
+        useEffect(() => {
+            if (inView && hasMore && !loading && !isInitialLoad) {
+                debouncedLoadMore();
+            }
+        }, [inView, hasMore, loading, isInitialLoad, debouncedLoadMore]);
+
+        // 채팅 방 생성 및 초기화
+        useEffect(() => {
+            if (draftId && currentUser) {
+                createOrGetChatRoom();
+            }
+        }, [draftId, currentUser]);
+
+        // 채팅방 ID가 설정된 후 채팅 기록 로드
+        useEffect(() => {
+            if (chatRoomId && currentUser) {
+                loadInitialHistory();
+            }
+        }, [chatRoomId, currentUser]);
+
+        // 사용자 정보 로드
+        useEffect(() => {
+            fetchCurrentUser();
+        }, []);
+
+        // 채팅 WebSocket 연결 (채팅방 ID가 설정된 후)
+        useEffect(() => {
+            if (chatRoomId && currentUser && !isConnected) {
+                connectChatWebSocket();
+            }
+        }, [chatRoomId, currentUser, connectChatWebSocket]);
+
+        useEffect(() => {
+            if (chatBoxRef.current) {
+                chatBoxRef.current.scrollTop = chatBoxRef.current.scrollHeight;
+            }
+        }, [chatList]);
+
+        // 채팅 메시지 스크롤 자동 이동
+        useEffect(() => {
+            if (chatBoxRef.current && chatList.length > 0) {
+                const {
+                    scrollTop,
+                    scrollHeight,
+                    clientHeight
+                } = chatBoxRef.current;
+                const isNearBottom = scrollHeight - scrollTop - clientHeight
+                    < 100;
+
+                if (isNearBottom) {
+                    setTimeout(() => {
+                        if (chatBoxRef.current) {
+                            chatBoxRef.current.scrollTop = chatBoxRef.current.scrollHeight;
+                        }
+                    }, 100);
+                }
+            }
+        }, [chatList]);
+
+        // 현재 턴인 참가자 정보 가져오기
+        const getCurrentTurnParticipant = () => {
+            if (!draftStarted || participants.length === 0
+                || draftCompleted) return null;
+            return participants[currentTurnIndex];
+        };
+
+        const currentTurnParticipant = getCurrentTurnParticipant();
+        const selectedParticipantDraftedPlayers = getSelectedParticipantDraftedPlayers();
+
+        return (
+            <>
+                {/* Hidden draftId value */}
+                <div style={{display: 'none'}} data-draft-id={draftId}></div>
+
+                {/* Hidden drafted players data */}
+                <div style={{display: 'none'}} id="drafted-players-data">
+                    {draftedPlayers.map((player, idx) => (
+                        <div key={idx}
+                             data-drafted-player={JSON.stringify(player)}></div>
+                    ))}
                 </div>
-            )}
 
-            {/* 드래프트 완료 오버레이 */}
-            {draftCompleted && (
-                <div className="countdown-overlay">
-                    <div className="countdown-content">
-                        <h2>드래프트가 완료되었습니다.</h2>
-                        <p style={{ marginTop: '1rem', fontSize: '1.2rem', opacity: 0.9 }}>
-                            3초 후 채팅방으로 이동합니다...
-                        </p>
+                {/* 드래프트 시작 카운트다운 오버레이 */}
+                {showCountdown && (
+                    <div className="countdown-overlay">
+                        <div className="countdown-content">
+                            <h2>{countdown}초 후에 드래프트가 시작됩니다.</h2>
+                        </div>
                     </div>
-                </div>
-            )}
+                )}
 
-            {/* 경고 메시지 오버레이 */}
-            {showWarningMessage && (
-                <div className="warning-overlay">
-                    <div className="warning-content">
-                        <p>현재 다른 참가자의 차례입니다.</p>
+                {/* 드래프트 완료 오버레이 */}
+                {draftCompleted && (
+                    <div className="countdown-overlay">
+                        <div className="countdown-content">
+                            <h2>드래프트가 완료되었습니다.</h2>
+                        </div>
                     </div>
-                </div>
-            )}
+                )}
 
-            <header className="header">
-                <div className="logo">Fantasy11</div>
-                <button
-                    className="cancel-btn"
-                    disabled={!chatRoomId}
-                    onClick={() => navigate(`/chatroom/${chatRoomId}`)}
-                >
+                {/* 경고 메시지 오버레이 */}
+                {showWarningMessage && (
+                    <div className="warning-overlay">
+                        <div className="warning-content">
+                            <p>현재 다른 참가자의 차례입니다.</p>
+                        </div>
+                    </div>
+                )}
+
+                {/* 3. 선수 선택 알림 메시지 오버레이 */}
+                {showPlayerSelectMessage && (
+                    <div className="player-select-overlay">
+                        <div className="player-select-content">
+                            <p>{playerSelectMessage}</p>
+                        </div>
+                    </div>
+                )}
+
+                <header className="header">
+                    <div className="logo">Fantasy11</div>
+                    {/* <button className="cancel-btn" onClick={() => navigate('/chatroom')}>
                     👉 채팅방 이동 (개발용)
-                </button>
-                <div className="draft-info">
-                    <span>라운드 2/11</span>
-                    <div className="timer">{formatDraftTime(draftTime)}</div>
-                    <span>
+                </button> */}
+                    <div className="draft-info">
+                        <span>라운드 {currentRound}/11</span>
+                        <div className="timer">{formatTimerDisplay(
+                            draftTime)}</div>
+                        <span>
                         {currentTurnParticipant && (
-                            `턴: ${!isBot(currentTurnParticipant) && currentTurnParticipant.userName && currentTurnParticipant.userName.trim() !== ""
+                            `턴: ${!isBot(currentTurnParticipant)
+                            && currentTurnParticipant.userName
+                            && currentTurnParticipant.userName.trim() !== ""
                                 ? currentTurnParticipant.userName
                                 : `Bot${currentTurnIndex + 1}`}님`
                         )}
                     </span>
-                </div>
-                <button className="exit-btn" onClick={handleExit}>나가기</button>
-            </header>
+                    </div>
+                    <button className="exit-btn" onClick={handleExit}>나가기
+                    </button>
+                </header>
 
-            <div className="main-container">
-                {/* 채팅 */}
-                <div className="section chat-section">
-                    <div className="section-title">
-                        채팅
-                        {unreadCount > 0 && <span className="unread-count">미읽음 {unreadCount}</span>}
-                        {loading && <span className="loading-indicator"> 로딩중...</span>}
-                    </div>
+                <div className="main-container">
+                    {/* 채팅 */}
+                    <div className="section chat-section">
+                        <h3 className="section-title">
+                            채팅
+                            {!isConnected && <span
+                                className="connection-status disconnected"> 연결 중...</span>}
+                            {isConnected && <span
+                                className="connection-status connected"> 연결됨</span>}
+                            {loading && <span
+                                className="loading-indicator"> 로딩중...</span>}
+                        </h3>
 
-                    {/* 채팅 검색 영역 */}
-                    <div className="chat-search-container">
-                        <input
-                            type="text"
-                            className="chat-search-input"
-                            value={searchQuery}
-                            onChange={(e) => setSearchQuery(e.target.value)}
-                            onKeyDown={(e) => {
-                                if (e.key === 'Enter') {
-                                    e.preventDefault();
-                                    handleChatSearch();
-                                }
-                            }}
-                            placeholder="채팅 메시지 검색..."
-                        />
-                        <button
-                            className="chat-search-btn"
-                            onClick={handleChatSearch}
-                            disabled={isSearching || !searchQuery.trim()}
-                        >
-                            {isSearching ? '검색중...' : '🔍'}
-                        </button>
-                        {showSearchResults && (
-                            <button
-                                className="chat-search-clear"
-                                onClick={clearSearch}
-                                title="검색 결과 지우기"
-                            >
-                                ✕
-                            </button>
-                        )}
-                    </div>
-                    <div className="chat-messages" ref={chatRef}>
-                        {showSearchResults ? (
-                            /* 검색 결과 표시 */
-                            <>
-                                <div className="search-results-header">
-                                    검색 결과: "{searchQuery}" ({searchResults.length}건)
-                                </div>
-                                {searchResults.length > 0 ? (
-                                    searchResults.map((msg) => (
-                                        <div key={msg.id} className={`chat-message search-result ${msg.type === 'ALERT' ? 'alert-message' : ''}`}>
-                                            <div className="chat-user">{msg.user}</div>
-                                            <div className="chat-text">{msg.text}</div>
-                                            <div className="chat-time">{msg.time}</div>
-                                        </div>
-                                    ))
-                                ) : (
-                                    <div className="no-search-results">
-                                        검색 결과가 없습니다.
-                                    </div>
-                                )}
-                            </>
-                        ) : (
-                            /* 일반 채팅 메시지 표시 */
-                            <>
-                                {hasMore && (
-                                    <div ref={loadMoreRef} className="load-more-trigger">
-                                        {loading && <div className="loading-message">이전 메시지를 불러오는 중...</div>}
-                                    </div>
-                                )}
-                                {!hasMore && chatList.length > 0 && (
-                                    <div className="chat-end-message">채팅의 시작입니다.</div>
-                                )}
-                                {chatList.map((msg) => (
-                                    <div key={msg.id} className={`chat-message ${msg.type === 'ALERT' ? 'alert-message' : ''}`}>
-                                        <div className="chat-user">{msg.user}</div>
-                                        <div className="chat-text">{msg.text}</div>
-                                        <div className="chat-time">{msg.time}</div>
-                                    </div>
-                                ))}
-                            </>
-                        )}
-                    </div>
-                    <div className="chat-input-container">
-                        <input
-                            type="text"
-                            className="chat-input"
-                            value={message}
-                            onChange={(e) => setMessage(e.target.value)}
-                            onCompositionStart={() => setIsComposing(true)}
-                            onCompositionEnd={(e) => {
-                                setMessage(e.currentTarget.value);
-                                setIsComposing(false);
-                            }}
-                            onKeyDown={(e) => {
-                                const composing = isComposing || e.nativeEvent.isComposing;
-                                if (e.key === 'Enter' && !e.shiftKey) {
-                                    if (composing) return;
-                                    e.preventDefault();
-                                    handleSendMessage();
-                                }
-                            }}
-                            placeholder={isConnected ? "메시지를 입력하세요..." : "연결 중..."}
-                            disabled={!isConnected}
-                        />
-                        <button
-                            className="chat-send"
-                            onClick={handleSendMessage}
-                            disabled={!isConnected || !message.trim()}
-                        >
-                            전송
-                        </button>
-                    </div>
-                </div>
-
-                {/* 선수 선택 */}
-                <div className="section player-section">
-                    <h3 className="section-title">선수 선택</h3>
-                    <div className="search-container">
-                        <div className="search-form">
-                            <select
-                                name="elementTypeId"
-                                className="search-select"
-                                value={searchParams.elementTypeId}
-                                onChange={(e) => handleSearchInputChange('elementTypeId', e.target.value)}
-                            >
-                                <option value="">선택</option>
-                                {elementTypes.map(elementType => (
-                                    <option key={elementType.id} value={elementType.id}
-                                            data-squad-min-play={elementType.squadMinPlay}
-                                            data-squad-max-play={elementType.squadMaxPlay}
-                                    >
-                                        {elementType.krName && elementType.krName.trim() !== ''
-                                            ? elementType.krName
-                                            : elementType.pluralName}
-                                    </option>
-                                ))}
-                            </select>
+                        {/* 채팅 검색 영역 */}
+                        <div className="chat-search-container">
                             <input
                                 type="text"
-                                name="keyword"
-                                className="search-input"
-                                placeholder="선수 이름 또는 팀으로 검색..."
-                                value={searchParams.keyword}
-                                onChange={(e) => handleSearchInputChange('keyword', e.target.value)}
-                                onKeyPress={handleSearchKeyPress}
+                                className="chat-search-input"
+                                value={searchQuery}
+                                onChange={(e) => setSearchQuery(e.target.value)}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter') {
+                                        e.preventDefault();
+                                        handleChatSearch();
+                                    }
+                                }}
+                                placeholder="채팅 메시지 검색..."
                             />
                             <button
-                                type="button"
-                                className="search-btn"
-                                onClick={handleSearch}
+                                className="chat-search-btn"
+                                onClick={handleChatSearch}
+                                disabled={isSearching || !searchQuery.trim()}
                             >
-                                검색
+                                {isSearching ? '검색중...' : '🔍'}
+                            </button>
+                            {showSearchResults && (
+                                <button
+                                    className="chat-search-clear"
+                                    onClick={clearSearch}
+                                    title="검색 결과 지우기"
+                                >
+                                    ✕
+                                </button>
+                            )}
+                        </div>
+
+                        <div className="chat-messages" ref={chatBoxRef}>
+                            {showSearchResults ? (
+                                /* 검색 결과 표시 */
+                                <>
+                                    <div className="search-results-header">
+                                        검색 결과: "{searchQuery}"
+                                        ({searchResults.length}건)
+                                    </div>
+                                    {searchResults.length > 0 ? (
+                                        searchResults.map((msg) => (
+                                            <div key={msg.id}
+                                                 className={`chat-message search-result ${msg.type
+                                                 === 'ALERT' ? 'alert-message'
+                                                     : ''}`}>
+                                                <div
+                                                    className="chat-user">{msg.user}</div>
+                                                <div
+                                                    className="chat-text">{msg.text}</div>
+                                                <div
+                                                    className="chat-time">{msg.time}</div>
+                                            </div>
+                                        ))
+                                    ) : (
+                                        <div className="no-search-results">
+                                            검색 결과가 없습니다.
+                                        </div>
+                                    )}
+                                </>
+                            ) : (
+                                /* 일반 채팅 메시지 표시 */
+                                <>
+                                    {hasMore && (
+                                        <div ref={loadMoreRef}
+                                             className="load-more-trigger">
+                                            {loading && <div
+                                                className="loading-message">이전
+                                                메시지를 불러오는 중...</div>}
+                                        </div>
+                                    )}
+                                    {!hasMore && chatList.length > 0 && (
+                                        <div className="chat-end-message">채팅의
+                                            시작입니다.</div>
+                                    )}
+                                    {chatList.map((msg) => (
+                                        <div key={msg.id}
+                                             className={`chat-message ${msg.type
+                                             === 'ALERT' ? 'alert-message'
+                                                 : ''}`}>
+                                            <div
+                                                className="chat-user">{msg.user}</div>
+                                            <div className="chat-text">{msg.text
+                                                || msg.message}</div>
+                                            <div
+                                                className="chat-time">{msg.time}</div>
+                                        </div>
+                                    ))}
+                                </>
+                            )}
+                        </div>
+
+                        <div className="chat-input-container">
+                            <input
+                                type="text"
+                                className="chat-input"
+                                value={message}
+                                onChange={(e) => setMessage(e.target.value)}
+                                onCompositionStart={() => setIsComposing(true)}
+                                onCompositionEnd={(e) => {
+                                    setMessage(e.currentTarget.value);
+                                    setIsComposing(false);
+                                }}
+                                onKeyDown={(e) => {
+                                    const composing = isComposing
+                                        || e.nativeEvent.isComposing;
+                                    if (e.key === 'Enter' && !e.shiftKey) {
+                                        if (composing) {
+                                            return;
+                                        }
+                                        e.preventDefault();
+                                        handleSendMessage();
+                                    }
+                                }}
+                                placeholder={isConnected ? "메시지를 입력하세요..."
+                                    : "연결 중..."}
+                                disabled={!isConnected}
+                                maxLength={100}
+                            />
+                            <button
+                                className="chat-send"
+                                onClick={handleSendMessage}
+                                disabled={!isConnected || !message.trim()}
+                            >
+                                전송
                             </button>
                         </div>
                     </div>
-                    <div className="player-list">
-                        {/* 로딩 중일 때 */}
-                        {playersLoading && (
-                            <div className="loading-message">선수 데이터를 불러오는 중...</div>
-                        )}
 
-                        {/* 에러 발생시 */}
-                        {error && (
-                            <div className="error-message">
-                                선수 데이터를 불러오는데 실패했습니다: {error}
-                            </div>
-                        )}
-
-                        {/* 선수 목록 */}
-                        {!playersLoading && !error && players.map((player, idx) => (
-                            <div key={player.id || idx} className="player-item">
-                                <div className="player-position">{player.position}</div>
-                                <div className="player-photo">
-                                    {player.pic ? (
-                                        <img
-                                            src={player.pic}
-                                            alt={player.name}
-                                            onError={(e) => {
-                                                e.target.style.display = 'none';
-                                            }}
-                                        />
-                                    ) : (
-                                        <div className="no-photo">NO IMG</div>
-                                    )}
-                                </div>
-                                <div className="player-info">
-                                    <div className="player-name">{player.name}</div>
-                                    <div className="player-team">{player.team}</div>
-                                </div>
-                                <button
-                                    className="select-btn"
-                                    disabled={
-                                        myPlayerCount >= 11 ||
-                                        !isPlayerSelectable(player.status) ||
-                                        draftCompleted ||
-                                        isSelectingPlayer ||
-                                        selectedPlayerIds.includes(player.id)
-                                    }
-                                    onClick={() => handlePlayerSelect(player)}
-                                    title={
-                                        selectedPlayerIds.includes(player.id) ? '이미 선택된 선수입니다' :
-                                            !isPlayerSelectable(player.status) ? getStatusReason(player.status) : ''
-                                    }
+                    {/* 선수 선택 */}
+                    <div className="section player-section">
+                        <h3 className="section-title">선수 선택</h3>
+                        <div className="search-container">
+                            <div className="search-form">
+                                <select
+                                    name="elementTypeId"
+                                    className="search-select"
+                                    value={searchParams.elementTypeId}
+                                    onChange={(e) => handleSearchInputChange(
+                                        'elementTypeId', e.target.value)}
                                 >
-                                    {selectedPlayerIds.includes(player.id) ? '선택됨' :
-                                        isSelectingPlayer ? '선택 중...' : '선택'}
+                                    <option value="">선택</option>
+                                    {elementTypes.map(elementType => (
+                                        <option key={elementType.id}
+                                                value={elementType.id}
+                                                data-squad-min-play={elementType.squadMinPlay}
+                                                data-squad-max-play={elementType.squadMaxPlay}
+                                        >
+                                            {elementType.krName
+                                            && elementType.krName.trim() !== ''
+                                                ? elementType.krName
+                                                : elementType.pluralName}
+                                        </option>
+                                    ))}
+                                </select>
+                                <input
+                                    type="text"
+                                    name="keyword"
+                                    className="search-input"
+                                    placeholder="선수 이름 또는 팀으로 검색..."
+                                    value={searchParams.keyword}
+                                    onChange={(e) => handleSearchInputChange(
+                                        'keyword', e.target.value)}
+                                    onKeyPress={handleSearchKeyPress}
+                                />
+                                <button
+                                    type="button"
+                                    className="search-btn"
+                                    onClick={handlePlayerSearch}
+                                >
+                                    검색
                                 </button>
-
-                                {/* hidden 데이터들 (화면에는 보이지 않음) */}
-                                <div style={{ display: 'none' }}>
-                                    <span data-id={player.id}></span>
-                                    <span data-web-name={player.webName}></span>
-                                    <span data-kr-name={player.krName}></span>
-                                    <span data-status={player.status}></span>
-                                    <span data-team-name={player.teamName}></span>
-                                    <span data-team-kr-name={player.teamKrName}></span>
-                                    <span data-element-type-id={player.elementTypeId}></span>
-                                    <span data-element-type-plural-name={player.elementTypePluralName}></span>
-                                    <span data-element-type-kr-name={player.elementTypeKrName}></span>
-                                </div>
                             </div>
-                        ))}
-                    </div>
-                </div>
-
-                {/* 참가자 + 내 선수 정보 */}
-                <div className="section info-section">
-                    <div>
-                        <h3 className="section-title">참가자 ({participants.length}명)</h3>
-                        <div className="users-grid">
-                            {participantLoading && (
-                                <div className="loading-message">참가자 정보를 불러오는 중...</div>
+                        </div>
+                        <div className="player-list">
+                            {/* 로딩 중일 때 */}
+                            {playersLoading && (
+                                <div className="loading-message">선수 데이터를 불러오는
+                                    중...</div>
                             )}
 
-                            {participantError && (
+                            {/* 에러 발생시 */}
+                            {error && (
                                 <div className="error-message">
-                                    참가자 정보를 불러오는데 실패했습니다: {participantError}
+                                    선수 데이터를 불러오는데 실패했습니다: {error}
                                 </div>
                             )}
 
-                            {!participantLoading && !participantError && participants.map((participant, idx) => {
-                                const participantIsBot = isBot(participant);
-                                const displayName = participantIsBot
-                                    ? `Bot${idx + 1}`
-                                    : (participant.userName && participant.userName.trim() !== ""
-                                        ? participant.userName
-                                        : `User${idx + 1}`);
-
-                                const pickCount = participantPickCounts[participant.participantId] || 0;
-
-                                return (
-                                    <div
-                                        key={participant.participantId}
-                                        className={`user-card ${draftStarted && !draftCompleted && idx === currentTurnIndex ? 'active' : ''} ${participantIsBot ? 'bot-card' : ''} ${selectedParticipantId === participant.participantId ? 'selected' : ''}`}
-                                        onClick={() => handleParticipantCardClick(participant.participantId)}
-                                        style={{ cursor: 'pointer' }}
-                                    >
-                                        <div className="user-name">
-                                            {displayName}
-                                            {participantIsBot && <span className="bot-badge">🤖</span>}
+                            {/* 선수 목록 */}
+                            {!playersLoading && !error && players.map(
+                                (player, idx) => (
+                                    <div key={player.id || idx}
+                                         className="player-item">
+                                        <div
+                                            className="player-position">{player.position}</div>
+                                        <div className="player-photo">
+                                            {player.pic ? (
+                                                <img
+                                                    src={player.pic}
+                                                    alt={player.name}
+                                                    onError={(e) => {
+                                                        e.target.style.display = 'none';
+                                                    }}
+                                                />
+                                            ) : (
+                                                <div className="no-photo">NO
+                                                    IMG</div>
+                                            )}
                                         </div>
-                                        <div className="user-picks">
-                                            {pickCount}/11 선택
-                                            {draftStarted && !draftCompleted && idx === currentTurnIndex && ' (현재 턴)'}
-                                            {participantIsBot && draftStarted && !draftCompleted && idx === currentTurnIndex && ' (선택 중...)'}
+                                        <div className="player-info">
+                                            <div
+                                                className="player-name">{player.name}</div>
+                                            <div
+                                                className="player-team">{player.team}</div>
                                         </div>
+                                        <button
+                                            className="select-btn"
+                                            disabled={
+                                                myPlayerCount >= 11 ||
+                                                !isPlayerSelectable(
+                                                    player.status) ||
+                                                draftCompleted ||
+                                                isSelectingPlayer ||
+                                                selectedPlayerIds.includes(
+                                                    player.id)
+                                            }
+                                            onClick={() => handlePlayerSelect(
+                                                player)}
+                                            title={
+                                                selectedPlayerIds.includes(
+                                                    player.id) ? '이미 선택된 선수입니다'
+                                                    :
+                                                    !isPlayerSelectable(
+                                                        player.status)
+                                                        ? getStatusReason(
+                                                            player.status) : ''
+                                            }
+                                        >
+                                            {selectedPlayerIds.includes(
+                                                player.id) ? '선택됨' :
+                                                isSelectingPlayer ? '선택 중...'
+                                                    : '선택'}
+                                        </button>
 
-                                        {/* hidden 데이터들 */}
-                                        <div style={{ display: 'none' }}>
-                                            <span data-participant-id={participant.participantId}></span>
-                                            <span data-participant-user-number={participant.participantUserNumber}></span>
-                                            <span data-participant-dummy={participant.participantDummy}></span>
-                                            <span data-user-email={participant.userEmail}></span>
-                                            <span data-user-name={displayName}></span>
-                                            <span data-user-flag={participant.userFlag}></span>
-                                            <span data-is-bot={participantIsBot}></span>
-                                            <span data-is-user={participant.userFlag === true}></span>
+                                        {/* hidden 데이터들 (화면에는 보이지 않음) */}
+                                        <div style={{display: 'none'}}>
+                                            <span data-id={player.id}></span>
+                                            <span
+                                                data-web-name={player.webName}></span>
+                                            <span
+                                                data-kr-name={player.krName}></span>
+                                            <span
+                                                data-status={player.status}></span>
+                                            <span
+                                                data-team-name={player.teamName}></span>
+                                            <span
+                                                data-team-kr-name={player.teamKrName}></span>
+                                            <span
+                                                data-element-type-id={player.elementTypeId}></span>
+                                            <span
+                                                data-element-type-plural-name={player.elementTypePluralName}></span>
+                                            <span
+                                                data-element-type-kr-name={player.elementTypeKrName}></span>
                                         </div>
                                     </div>
-                                );
-                            })}
+                                ))}
                         </div>
                     </div>
 
-                    <div style={{ flex: 1 }}>
-                        <h3 className="section-title">
-                            {selectedParticipantId ?
-                                `선택된 참가자의 선수 (${selectedParticipantDraftedPlayers.length}/11)` :
-                                `내 선수 (${myPlayerCount}/11)`
-                            }
-                        </h3>
-                        <div className="my-players">
-                            {draftedPlayersLoading && (
-                                <div className="loading-message">드래프트된 선수 정보를 불러오는 중...</div>
-                            )}
+                    {/* 참가자 + 내 선수 정보 */}
+                    <div className="section info-section">
+                        <div>
+                            <h3 className="section-title">참가자
+                                ({participants.length}명)</h3>
+                            <div className="users-grid">
+                                {participantLoading && (
+                                    <div className="loading-message">참가자 정보를
+                                        불러오는 중...</div>
+                                )}
 
-                            {draftedPlayersError && (
-                                <div className="error-message">
-                                    드래프트된 선수 정보를 불러오는데 실패했습니다: {draftedPlayersError}
-                                </div>
-                            )}
+                                {participantError && (
+                                    <div className="error-message">
+                                        참가자 정보를 불러오는데 실패했습니다: {participantError}
+                                    </div>
+                                )}
 
-                            {!draftedPlayersLoading && !draftedPlayersError && selectedParticipantDraftedPlayers.length === 0 && (
-                                <div className="no-players-message">
-                                    {selectedParticipantId ? '아직 선택된 선수가 없습니다.' : '참가자를 클릭하여 선수를 확인하세요.'}
-                                </div>
-                            )}
+                                {!participantLoading && !participantError
+                                    && participants.map((participant, idx) => {
+                                        const participantIsBot = isBot(
+                                            participant);
+                                        const displayName = participantIsBot
+                                            ? `Bot${idx + 1}`
+                                            : (participant.userName
+                                            && participant.userName.trim()
+                                            !== ""
+                                                ? participant.userName
+                                                : `User${idx + 1}`);
 
-                            {!draftedPlayersLoading && !draftedPlayersError && selectedParticipantDraftedPlayers.map((draftedPlayer, idx) => (
-                                <div key={`${draftedPlayer.participantId}-${draftedPlayer.playerId}-${idx}`} className="my-player-item">
-                                    <div className="my-player-position">
-                                        {getPositionCodeFromPluralName(draftedPlayer.elementTypePluralName)}
-                                    </div>
-                                    <div className="my-player-photo">
-                                        {draftedPlayer.playerPic ? (
-                                            <img
-                                                src={draftedPlayer.playerPic}
-                                                alt={draftedPlayer.playerKrName || draftedPlayer.playerWebName}
-                                                onError={(e) => {
-                                                    e.target.style.display = 'none';
-                                                }}
-                                            />
-                                        ) : (
-                                            <div className="no-photo-small">NO IMG</div>
-                                        )}
-                                    </div>
-                                    <div className="my-player-name">
-                                        {draftedPlayer.playerKrName && draftedPlayer.playerKrName.trim() !== ''
-                                            ? draftedPlayer.playerKrName
-                                            : draftedPlayer.playerWebName}
-                                    </div>
+                                        const pickCount = participantPickCounts[participant.participantId]
+                                            || 0;
 
-                                    {/* hidden 데이터들 (화면에는 보이지 않음) */}
-                                    <div style={{ display: 'none' }}>
-                                        <span data-participant-id={draftedPlayer.participantId}></span>
-                                        <span data-player-id={draftedPlayer.playerId}></span>
-                                        <span data-player-web-name={draftedPlayer.playerWebName}></span>
-                                        <span data-player-kr-name={draftedPlayer.playerKrName}></span>
-                                        <span data-player-pic={draftedPlayer.playerPic}></span>
-                                        <span data-team-id={draftedPlayer.teamId}></span>
-                                        <span data-team-name={draftedPlayer.teamName}></span>
-                                        <span data-team-kr-name={draftedPlayer.teamKrName}></span>
-                                        <span data-element-type-id={draftedPlayer.elementTypeId}></span>
-                                        <span data-element-type-plural-name={draftedPlayer.elementTypePluralName}></span>
-                                        <span data-element-type-kr-name={draftedPlayer.elementTypeKrName}></span>
+                                        return (
+                                            <div
+                                                key={participant.participantId}
+                                                className={`user-card ${draftStarted
+                                                && !draftCompleted && idx
+                                                === currentTurnIndex ? 'active'
+                                                    : ''} ${participantIsBot
+                                                    ? 'bot-card'
+                                                    : ''} ${selectedParticipantId
+                                                === participant.participantId
+                                                    ? 'selected' : ''}`}
+                                                onClick={() => handleParticipantCardClick(
+                                                    participant.participantId)}
+                                                style={{cursor: 'pointer'}}
+                                            >
+                                                <div className="user-name">
+                                                    {displayName}
+                                                    {participantIsBot && <span
+                                                        className="bot-badge">🤖</span>}
+                                                </div>
+                                                <div className="user-picks">
+                                                    {pickCount}/11 선택
+                                                    {draftStarted
+                                                        && !draftCompleted
+                                                        && idx
+                                                        === currentTurnIndex
+                                                        && ' (현재 턴)'}
+                                                    {participantIsBot
+                                                        && draftStarted
+                                                        && !draftCompleted
+                                                        && idx
+                                                        === currentTurnIndex
+                                                        && ' (선택 중...)'}
+                                                </div>
+
+                                                {/* hidden 데이터들 */}
+                                                <div style={{display: 'none'}}>
+                                                    <span
+                                                        data-participant-id={participant.participantId}></span>
+                                                    <span
+                                                        data-participant-user-number={participant.participantUserNumber}></span>
+                                                    <span
+                                                        data-participant-dummy={participant.participantDummy}></span>
+                                                    <span
+                                                        data-user-email={participant.userEmail}></span>
+                                                    <span
+                                                        data-user-name={displayName}></span>
+                                                    <span
+                                                        data-user-flag={participant.userFlag}></span>
+                                                    <span
+                                                        data-is-bot={participantIsBot}></span>
+                                                    <span
+                                                        data-is-user={participant.userFlag
+                                                            === true}></span>
+                                                </div>
+                                            </div>
+                                        );
+                                    })}
+                            </div>
+                        </div>
+
+                        <div style={{flex: 1}}>
+                            <h3 className="section-title">
+                                {selectedParticipantId ?
+                                    `선택된 참가자의 선수 (${selectedParticipantDraftedPlayers.length}/11)`
+                                    :
+                                    `내 선수 (${myPlayerCount}/11)`
+                                }
+                            </h3>
+                            <div className="my-players">
+                                {draftedPlayersLoading && (
+                                    <div className="loading-message">드래프트된 선수
+                                        정보를 불러오는 중...</div>
+                                )}
+
+                                {draftedPlayersError && (
+                                    <div className="error-message">
+                                        드래프트된 선수 정보를 불러오는데
+                                        실패했습니다: {draftedPlayersError}
                                     </div>
-                                </div>
-                            ))}
+                                )}
+
+                                {!draftedPlayersLoading && !draftedPlayersError
+                                    && selectedParticipantDraftedPlayers.length
+                                    === 0 && (
+                                        <div className="no-players-message">
+                                            {selectedParticipantId
+                                                ? '아직 선택된 선수가 없습니다.'
+                                                : '참가자를 클릭하여 선수를 확인하세요.'}
+                                        </div>
+                                    )}
+
+                                {!draftedPlayersLoading && !draftedPlayersError
+                                    && selectedParticipantDraftedPlayers.map(
+                                        (draftedPlayer, idx) => (
+                                            <div key={idx}
+                                                 className="my-player-item">
+                                                <div
+                                                    className="my-player-position">
+                                                    {getPositionCodeFromPluralName(
+                                                        draftedPlayer.elementTypePluralName)}
+                                                </div>
+                                                <div
+                                                    className="my-player-photo">
+                                                    {draftedPlayer.playerPic ? (
+                                                        <img
+                                                            src={draftedPlayer.playerPic}
+                                                            alt={draftedPlayer.playerKrName
+                                                                || draftedPlayer.playerWebName}
+                                                            onError={(e) => {
+                                                                e.target.style.display = 'none';
+                                                            }}
+                                                        />
+                                                    ) : (
+                                                        <div
+                                                            className="no-photo-small">NO
+                                                            IMG</div>
+                                                    )}
+                                                </div>
+                                                <div className="my-player-name">
+                                                    {draftedPlayer.playerKrName
+                                                    && draftedPlayer.playerKrName.trim()
+                                                    !== ''
+                                                        ? draftedPlayer.playerKrName
+                                                        : draftedPlayer.playerWebName}
+                                                </div>
+
+                                                {/* hidden 데이터들 (화면에는 보이지 않음) */}
+                                                <div style={{display: 'none'}}>
+                                                    <span
+                                                        data-participant-id={draftedPlayer.participantId}></span>
+                                                    <span
+                                                        data-player-id={draftedPlayer.playerId}></span>
+                                                    <span
+                                                        data-player-web-name={draftedPlayer.playerWebName}></span>
+                                                    <span
+                                                        data-player-kr-name={draftedPlayer.playerKrName}></span>
+                                                    <span
+                                                        data-player-pic={draftedPlayer.playerPic}></span>
+                                                    <span
+                                                        data-team-id={draftedPlayer.teamId}></span>
+                                                    <span
+                                                        data-team-name={draftedPlayer.teamName}></span>
+                                                    <span
+                                                        data-team-kr-name={draftedPlayer.teamKrName}></span>
+                                                    <span
+                                                        data-element-type-id={draftedPlayer.elementTypeId}></span>
+                                                    <span
+                                                        data-element-type-plural-name={draftedPlayer.elementTypePluralName}></span>
+                                                    <span
+                                                        data-element-type-kr-name={draftedPlayer.elementTypeKrName}></span>
+                                                </div>
+                                            </div>
+                                        ))}
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-        </>
-    );
-}
+            </>
+        );
+    }


### PR DESCRIPTION
Changes
---
- 채팅방 기능 오류 수정
- 드래프트 페이지 포메이션 스크롤 기능, 선수 사진추가 및 점수 표현 추가
- 점수 로직 변경에 맞춘 프론트 코드 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Player points badge on player cards.
  - Full-screen player selection overlay in Draft.
  - Formation view shows player photos, names fallback, and loading placeholder.

- Enhancements
  - Refined player card visuals and avatars; improved typography and spacing.
  - Increased chat history per load to 30 messages.
  - Auto-selects first participant and loads roster on scoreboard load.
  - Smoother auto-scroll for new messages.
  - Real-time updates refresh scoreboard and roster after alerts.
  - Mobile/responsive tweaks for avatars and text.
  - Localized unknown author label to Korean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->